### PR TITLE
Add video decoding support.

### DIFF
--- a/FFMediaToolkit/src/Common/FFDictionary.cs
+++ b/FFMediaToolkit/src/Common/FFDictionary.cs
@@ -60,7 +60,7 @@
         public string Get(string key, bool matchCase = true)
         {
             var ptr = ffmpeg.av_dict_get(Pointer, key, null, matchCase ? ffmpeg.AV_DICT_MATCH_CASE : 0);
-            return ptr != null ? StringConverter.StringFromUtf8(new IntPtr(ptr)) : null;
+            return ptr != null ? new IntPtr(ptr).Utf8ToString() : null;
         }
 
         /// <summary>

--- a/FFMediaToolkit/src/Common/FFDictionary.cs
+++ b/FFMediaToolkit/src/Common/FFDictionary.cs
@@ -52,6 +52,26 @@
         }
 
         /// <summary>
+        /// Converts a <see cref="AVDictionary"/> to the managed string dictionary.
+        /// </summary>
+        /// <param name="dictionary">The <see cref="AVDictionary"/> to converter.</param>
+        /// <returns>The converted <see cref="Dictionary{TKey, TValue}"/>.</returns>
+        public static Dictionary<string, string> ToDictionary(AVDictionary* dictionary)
+        {
+            var result = new Dictionary<string, string>();
+
+            var item = ffmpeg.av_dict_get(dictionary, string.Empty, null, 0);
+
+            while (item != null)
+            {
+                result[new IntPtr(item->key).Utf8ToString()] = new IntPtr(item->value).Utf8ToString();
+                item = ffmpeg.av_dict_get(dictionary, string.Empty, item, 0);
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// Gets the value with specified key.
         /// </summary>
         /// <param name="key">The dictionary key.</param>

--- a/FFMediaToolkit/src/Common/Internal/MediaPacket.cs
+++ b/FFMediaToolkit/src/Common/Internal/MediaPacket.cs
@@ -31,6 +31,11 @@
         public int StreamIndex => Pointer->stream_index;
 
         /// <summary>
+        /// Gets the presentation time stamp of the packet. <see langword="null"/> if is <c>AV_NOPTS_VALUE</c>.
+        /// </summary>
+        public long? Timestamp => Pointer->pts != ffmpeg.AV_NOPTS_VALUE ? Pointer->pts : (long?)null;
+
+        /// <summary>
         /// Converts an instance of <see cref="MediaPacket"/> to the unmanaged pointer.
         /// </summary>
         /// <param name="packet">A <see cref="MediaPacket"/> instance.</param>

--- a/FFMediaToolkit/src/Decoding/Internal/InputContainer.cs
+++ b/FFMediaToolkit/src/Decoding/Internal/InputContainer.cs
@@ -72,13 +72,24 @@
         }
 
         /// <summary>
+        /// Seeks stream to the specified video frame.
+        /// </summary>
+        /// <param name="frameNumber">The target video frame number.</param>
+        public void SeekFile(int frameNumber) => SeekFile(frameNumber.ToTimestamp(Video.Info.TimeBase));
+
+        /// <summary>
         /// Seeks stream to the specified target time.
         /// </summary>
-        /// <param name="target">The absolute target time.</param>
-        public void SeekFile(TimeSpan target)
+        /// <param name="targetTime">The absolute target time.</param>
+        public void SeekFile(TimeSpan targetTime) => SeekFile(targetTime.ToTimestamp(Video.Info.TimeBase));
+
+        /// <summary>
+        /// Seeks stream to the specified target timestamp.
+        /// </summary>
+        /// <param name="targetTs">The target timestamp in the default stream time base.</param>
+        public void SeekFile(long targetTs)
         {
-            var targetTs = target.ToTimestamp(Video.Info.TimeBase);
-            ffmpeg.av_seek_frame(Pointer, Video.Info.Index, targetTs, ffmpeg.AVSEEK_FLAG_BACKWARD).CatchAll($"Seek to {target} failed.");
+            ffmpeg.av_seek_frame(Pointer, Video.Info.Index, targetTs, ffmpeg.AVSEEK_FLAG_BACKWARD).CatchAll($"Seek to {targetTs} failed.");
             IsAtEndOfFile = false;
 
             Video.PacketQueue.Clear();
@@ -89,12 +100,20 @@
         /// <summary>
         /// Seeks stream by skipping next packets in the file. Useful to seek few frames forward.
         /// </summary>
-        /// <param name="target">The absolute target time.</param>
-        public void SeekForward(TimeSpan target)
-        {
-            var targetTs = target.ToTimestamp(Video.Info.TimeBase);
-            AdjustSeekPackets(Video.PacketQueue, targetTs);
-        }
+        /// <param name="frameNumber">The target video frame number.</param>
+        public void SeekForward(int frameNumber) => SeekForward(frameNumber.ToTimestamp(Video.Info.TimeBase));
+
+        /// <summary>
+        /// Seeks stream by skipping next packets in the file. Useful to seek few frames forward.
+        /// </summary>
+        /// <param name="targetTime">The absolute target time.</param>
+        public void SeekForward(TimeSpan targetTime) => SeekForward(targetTime.ToTimestamp(Video.Info.TimeBase));
+
+        /// <summary>
+        /// Seeks stream by skipping next packets in the file. Useful to seek few frames forward.
+        /// </summary>
+        /// <param name="targetTs">The target timestamp in the default stream time base.</param>
+        public void SeekForward(long targetTs) => AdjustSeekPackets(Video.PacketQueue, targetTs);
 
         /// <inheritdoc/>
         protected override void OnDisposing()

--- a/FFMediaToolkit/src/Decoding/Internal/InputContainer.cs
+++ b/FFMediaToolkit/src/Decoding/Internal/InputContainer.cs
@@ -34,6 +34,8 @@
         /// <returns>A new instance of the <see cref="InputContainer"/> class.</returns>
         public static InputContainer LoadFile(string path, MediaOptions options)
         {
+            MediaCore.LoadFFmpeg();
+
             var context = ffmpeg.avformat_alloc_context();
             options.DemuxerOptions.ApplyFlags(context);
             var dict = options.DemuxerOptions.PrivateOptions.Pointer;

--- a/FFMediaToolkit/src/Decoding/Internal/InputContainer.cs
+++ b/FFMediaToolkit/src/Decoding/Internal/InputContainer.cs
@@ -37,7 +37,8 @@
             options.DemuxerOptions.ApplyFlags(context);
             var dict = options.DemuxerOptions.PrivateOptions.Pointer;
 
-            ffmpeg.avformat_open_input(&context, path, null, &dict);
+            ffmpeg.avformat_open_input(&context, path, null, &dict)
+                .CatchAll("An error ocurred while opening the file");
 
             options.DemuxerOptions.PrivateOptions.Update(dict);
 

--- a/FFMediaToolkit/src/Decoding/Internal/InputContainer.cs
+++ b/FFMediaToolkit/src/Decoding/Internal/InputContainer.cs
@@ -77,8 +77,8 @@
         /// <param name="target">The absolute target time.</param>
         public void SeekFile(TimeSpan target)
         {
-            var targetTs = target.ToTimestamp(Video.TimeBase);
-            ffmpeg.av_seek_frame(Pointer, Video.Index, targetTs, ffmpeg.AVSEEK_FLAG_BACKWARD).CatchAll($"Seek to {target} failed.");
+            var targetTs = target.ToTimestamp(Video.Info.TimeBase);
+            ffmpeg.av_seek_frame(Pointer, Video.Info.Index, targetTs, ffmpeg.AVSEEK_FLAG_BACKWARD).CatchAll($"Seek to {target} failed.");
             Video.PacketQueue.Clear();
 
             long packetTs;
@@ -110,7 +110,7 @@
 
         private MediaType EnqueuePacket(MediaPacket packet)
         {
-            if (Video != null && packet.StreamIndex == Video.Index)
+            if (Video != null && packet.StreamIndex == Video.Info.Index)
             {
                 Video.PacketQueue.Enqueue(packet);
                 return MediaType.Video;
@@ -135,7 +135,7 @@
 
         private void OnPacketDequeued(object sender, MediaPacket packet)
         {
-            var stream = packet.StreamIndex == Video?.Index ? Video : null;
+            var stream = packet.StreamIndex == Video?.Info.Index ? Video : null;
             if (stream?.PacketQueue.Count > 5)
             {
                 return;

--- a/FFMediaToolkit/src/Decoding/Internal/InputContainer.cs
+++ b/FFMediaToolkit/src/Decoding/Internal/InputContainer.cs
@@ -86,6 +86,16 @@
             AdjustSeekPackets(Video.PacketQueue, targetTs);
         }
 
+        /// <summary>
+        /// Seeks stream by skipping next packets in the file. Useful to seek few frames forward.
+        /// </summary>
+        /// <param name="target">The absolute target time.</param>
+        public void SeekForward(TimeSpan target)
+        {
+            var targetTs = target.ToTimestamp(Video.Info.TimeBase);
+            AdjustSeekPackets(Video.PacketQueue, targetTs);
+        }
+
         /// <inheritdoc/>
         protected override void OnDisposing()
         {

--- a/FFMediaToolkit/src/Decoding/Internal/InputContainer.cs
+++ b/FFMediaToolkit/src/Decoding/Internal/InputContainer.cs
@@ -79,12 +79,11 @@
         {
             var targetTs = target.ToTimestamp(Video.Info.TimeBase);
             ffmpeg.av_seek_frame(Pointer, Video.Info.Index, targetTs, ffmpeg.AVSEEK_FLAG_BACKWARD).CatchAll($"Seek to {target} failed.");
+            IsAtEndOfFile = false;
 
             Video.PacketQueue.Clear();
             AddPacket(MediaType.Video);
             AdjustSeekPackets(Video.PacketQueue, targetTs);
-
-            IsAtEndOfFile = false;
         }
 
         /// <inheritdoc/>

--- a/FFMediaToolkit/src/Decoding/Internal/InputStream{TFrame}.cs
+++ b/FFMediaToolkit/src/Decoding/Internal/InputStream{TFrame}.cs
@@ -26,6 +26,7 @@
             PacketQueue = new ObservableQueue<MediaPacket>();
 
             Type = typeof(TFrame) == typeof(VideoFrame) ? MediaType.Video : MediaType.None;
+            Info = new StreamInfo(stream);
         }
 
         /// <summary>
@@ -44,14 +45,9 @@
         public MediaType Type { get; }
 
         /// <summary>
-        /// Gets the stream index.
+        /// Gets informations about the stream.
         /// </summary>
-        public int Index => Pointer->index;
-
-        /// <summary>
-        /// Gets the stream time base.
-        /// </summary>
-        public AVRational TimeBase => Pointer->time_base;
+        public StreamInfo Info { get; }
 
         /// <summary>
         /// Gets the packet queue.

--- a/FFMediaToolkit/src/Decoding/MediaFile.cs
+++ b/FFMediaToolkit/src/Decoding/MediaFile.cs
@@ -1,0 +1,69 @@
+﻿namespace FFMediaToolkit.Decoding
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using FFMediaToolkit.Common;
+    using FFMediaToolkit.Common.Internal;
+    using FFMediaToolkit.Decoding.Internal;
+
+    /// <summary>
+    /// Represents a multimedia file.
+    /// </summary>
+    public class MediaFile : IDisposable
+    {
+        private readonly InputContainer container;
+        private bool isDisposed;
+
+        private MediaFile(InputContainer container) => this.container = container;
+
+        /// <summary>
+        /// Opens a media file from the specified path.
+        /// </summary>
+        /// <param name="path">A path to the media file.</param>
+        /// <param name="options">The decoder settings.</param>
+        /// <returns>The opened <see cref="MediaFile"/>.</returns>
+        public static MediaFile Open(string path, MediaOptions options)
+        {
+            try
+            {
+                var container = InputContainer.LoadFile(path, options);
+                return new MediaFile(container);
+            }
+            catch (FileNotFoundException)
+            {
+                throw;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Failed to open the media file", ex);
+            }
+        }
+
+        /// <summary>
+        /// Opens a media file from the specified path asynchronously.
+        /// </summary>
+        /// <param name="path">A path to the media file.</param>
+        /// <param name="options">The decoder settings.</param>
+        /// <returns>The opened <see cref="MediaFile"/>.</returns>
+        public static async Task<MediaFile> OpenAsync(string path, MediaOptions options)
+            => await Task.Run(() => Open(path, options));
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (isDisposed)
+            {
+                return;
+            }
+
+            container.Dispose();
+
+            isDisposed = true;
+        }
+    }
+}

--- a/FFMediaToolkit/src/Decoding/MediaFile.cs
+++ b/FFMediaToolkit/src/Decoding/MediaFile.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.IO;
-    using System.Threading.Tasks;
     using FFMediaToolkit.Decoding.Internal;
 
     /// <summary>
@@ -66,15 +65,6 @@
                 throw new Exception("Failed to open the media file", ex);
             }
         }
-
-        /// <summary>
-        /// Opens a media file from the specified path asynchronously.
-        /// </summary>
-        /// <param name="path">A path to the media file.</param>
-        /// <param name="options">The decoder settings.</param>
-        /// <returns>The opened <see cref="MediaFile"/>.</returns>
-        public static async Task<MediaFile> OpenAsync(string path, MediaOptions options)
-            => await Task.Run(() => Open(path, options));
 
         /// <inheritdoc/>
         public void Dispose()

--- a/FFMediaToolkit/src/Decoding/MediaFile.cs
+++ b/FFMediaToolkit/src/Decoding/MediaFile.cs
@@ -3,8 +3,6 @@
     using System;
     using System.IO;
     using System.Threading.Tasks;
-    using FFMediaToolkit.Common;
-    using FFMediaToolkit.Common.Internal;
     using FFMediaToolkit.Decoding.Internal;
 
     /// <summary>
@@ -15,7 +13,25 @@
         private readonly InputContainer container;
         private bool isDisposed;
 
-        private MediaFile(InputContainer container) => this.container = container;
+        private MediaFile(InputContainer container, MediaOptions options)
+        {
+            this.container = container;
+
+            if (container.Video != null)
+            {
+                Video = new VideoStream(container.Video, options);
+            }
+        }
+
+        /// <summary>
+        /// Gets the video stream.
+        /// </summary>
+        public VideoStream Video { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the file contains video stream and the stream is loaded.
+        /// </summary>
+        public bool HasVideo => Video != null;
 
         /// <summary>
         /// Opens a media file from the specified path.
@@ -28,7 +44,7 @@
             try
             {
                 var container = InputContainer.LoadFile(path, options);
-                return new MediaFile(container);
+                return new MediaFile(container, options);
             }
             catch (FileNotFoundException)
             {
@@ -59,6 +75,12 @@
             if (isDisposed)
             {
                 return;
+            }
+
+            if (HasVideo)
+            {
+                ((IDisposable)Video).Dispose();
+                Video = null;
             }
 
             container.Dispose();

--- a/FFMediaToolkit/src/Decoding/MediaFile.cs
+++ b/FFMediaToolkit/src/Decoding/MediaFile.cs
@@ -13,7 +13,7 @@
         private readonly InputContainer container;
         private bool isDisposed;
 
-        private MediaFile(InputContainer container, MediaOptions options)
+        private unsafe MediaFile(InputContainer container, MediaOptions options)
         {
             this.container = container;
 
@@ -21,6 +21,8 @@
             {
                 Video = new VideoStream(container.Video, options);
             }
+
+            Info = new MediaInfo(container.Pointer);
         }
 
         /// <summary>
@@ -32,6 +34,11 @@
         /// Gets a value indicating whether the file contains video stream and the stream is loaded.
         /// </summary>
         public bool HasVideo => Video != null;
+
+        /// <summary>
+        /// Gets informations about the media container.
+        /// </summary>
+        public MediaInfo Info { get; }
 
         /// <summary>
         /// Opens a media file from the specified path.

--- a/FFMediaToolkit/src/Decoding/MediaInfo.cs
+++ b/FFMediaToolkit/src/Decoding/MediaInfo.cs
@@ -1,0 +1,60 @@
+﻿namespace FFMediaToolkit.Decoding
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using FFMediaToolkit.Common;
+    using FFMediaToolkit.Helpers;
+    using FFmpeg.AutoGen;
+
+    /// <summary>
+    /// Represents informations about the media container.
+    /// </summary>
+    public class MediaInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MediaInfo"/> class.
+        /// </summary>
+        /// <param name="container">The input container context.</param>
+        internal unsafe MediaInfo(AVFormatContext* container)
+        {
+            FilePath = new IntPtr(container->url).Utf8ToString();
+            ContainerFormat = new IntPtr(container->iformat->name).Utf8ToString();
+            Metadata = new ReadOnlyDictionary<string, string>(FFDictionary.ToDictionary(container->metadata));
+            Bitrate = container->bit_rate > 0 ? container->bit_rate : 0;
+
+            var timeBase = new AVRational { num = 1, den = ffmpeg.AV_TIME_BASE };
+            Duration = container->duration != ffmpeg.AV_NOPTS_VALUE ? container->duration.ToTimeSpan(timeBase) : TimeSpan.Zero;
+            StartTime = container->start_time != ffmpeg.AV_NOPTS_VALUE ? container->start_time.ToTimeSpan(timeBase) : TimeSpan.Zero;
+        }
+
+        /// <summary>
+        /// Gets the file path used to open the container.
+        /// </summary>
+        public string FilePath { get; }
+
+        /// <summary>
+        /// Gets the container format name.
+        /// </summary>
+        public string ContainerFormat { get; }
+
+        /// <summary>
+        /// Gets the container bitrate. 0 if unknow.
+        /// </summary>
+        public long Bitrate { get; }
+
+        /// <summary>
+        /// Gets the duration of the media container.
+        /// </summary>
+        public TimeSpan Duration { get; }
+
+        /// <summary>
+        /// Gets the media container start time.
+        /// </summary>
+        public TimeSpan StartTime { get; }
+
+        /// <summary>
+        /// Gets the container file metadata. Streams may contain additional metadata.
+        /// </summary>
+        public ReadOnlyDictionary<string, string> Metadata { get; }
+    }
+}

--- a/FFMediaToolkit/src/Decoding/MediaOptions.cs
+++ b/FFMediaToolkit/src/Decoding/MediaOptions.cs
@@ -1,5 +1,6 @@
 ﻿namespace FFMediaToolkit.Decoding
 {
+    using System.Drawing;
     using FFMediaToolkit.Common;
     using FFMediaToolkit.Graphics;
 
@@ -56,6 +57,11 @@
         /// Gets or sets the target pixel format for decoded video frames conversion. The default value is <c>BGR24</c>.
         /// </summary>
         public ImagePixelFormat VideoPixelFormat { get; set; } = ImagePixelFormat.BGR24;
+
+        /// <summary>
+        /// Gets or sets the target video size for decoded video frames conversion. <see langword="null"/>, if no rescale.
+        /// </summary>
+        public Size? TargetVideoSize { get; set; }
 
         /// <summary>
         /// Gets or sets the number of decoder threads (by the 'threads' flag). The default value is <see langword="null"/> - 'auto'.

--- a/FFMediaToolkit/src/Decoding/StreamInfo.cs
+++ b/FFMediaToolkit/src/Decoding/StreamInfo.cs
@@ -30,6 +30,7 @@
             Duration = stream->duration.ToTimeSpan(stream->time_base);
             var start = stream->start_time.ToTimeSpan(stream->time_base);
             StartTime = start == TimeSpan.MinValue ? TimeSpan.Zero : start;
+            FrameCount = Duration.ToFrameNumber(TimeBase);
         }
 
         /// <summary>
@@ -66,6 +67,11 @@
         /// Gets the video frame dimensions and pixel format.
         /// </summary>
         public Layout Dimensions { get; }
+
+        /// <summary>
+        /// Gets the estimated number of frames in the stream.
+        /// </summary>
+        public int FrameCount { get; }
 
         /// <summary>
         /// Gets the stream duration.

--- a/FFMediaToolkit/src/Decoding/StreamInfo.cs
+++ b/FFMediaToolkit/src/Decoding/StreamInfo.cs
@@ -30,7 +30,7 @@
             Duration = stream->duration.ToTimeSpan(stream->time_base);
             var start = stream->start_time.ToTimeSpan(stream->time_base);
             StartTime = start == TimeSpan.MinValue ? TimeSpan.Zero : start;
-            FrameCount = Duration.ToFrameNumber(TimeBase);
+            FrameCount = Duration.ToFrameNumber(FrameRate);
         }
 
         /// <summary>

--- a/FFMediaToolkit/src/Decoding/StreamInfo.cs
+++ b/FFMediaToolkit/src/Decoding/StreamInfo.cs
@@ -22,6 +22,7 @@
             Metadata = new ReadOnlyDictionary<string, string>(FFDictionary.ToDictionary(stream->metadata));
             CodecName = ffmpeg.avcodec_get_name(codec->codec_id);
             CodecId = FormatCodecId(codec->codec_id);
+            Index = stream->index;
             IsInterlaced = codec->field_order != AVFieldOrder.AV_FIELD_PROGRESSIVE && codec->field_order != AVFieldOrder.AV_FIELD_UNKNOWN;
             Dimensions = new Layout(codec->pix_fmt, codec->width, codec->height);
             TimeBase = stream->time_base;
@@ -30,6 +31,11 @@
             var start = stream->start_time.ToTimeSpan(stream->time_base);
             StartTime = start == TimeSpan.MinValue ? TimeSpan.Zero : start;
         }
+
+        /// <summary>
+        /// Gets the stream index.
+        /// </summary>
+        public int Index { get; }
 
         /// <summary>
         /// Gets the codec name.

--- a/FFMediaToolkit/src/Decoding/StreamInfo.cs
+++ b/FFMediaToolkit/src/Decoding/StreamInfo.cs
@@ -1,0 +1,81 @@
+﻿namespace FFMediaToolkit.Decoding
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using FFMediaToolkit.Common;
+    using FFMediaToolkit.Graphics;
+    using FFMediaToolkit.Helpers;
+    using FFmpeg.AutoGen;
+
+    /// <summary>
+    /// Represents informations about the video stream.
+    /// </summary>
+    public class StreamInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamInfo"/> class.
+        /// </summary>
+        /// <param name="stream">The video stram.</param>
+        internal unsafe StreamInfo(AVStream* stream)
+        {
+            var codec = stream->codec;
+            Metadata = new ReadOnlyDictionary<string, string>(FFDictionary.ToDictionary(stream->metadata));
+            CodecName = ffmpeg.avcodec_get_name(codec->codec_id);
+            CodecId = FormatCodecId(codec->codec_id);
+            IsInterlaced = codec->field_order != AVFieldOrder.AV_FIELD_PROGRESSIVE && codec->field_order != AVFieldOrder.AV_FIELD_UNKNOWN;
+            Dimensions = new Layout(codec->pix_fmt, codec->width, codec->height);
+            TimeBase = stream->time_base;
+            FrameRate = stream->r_frame_rate.ToDouble();
+            Duration = stream->duration.ToTimeSpan(stream->time_base);
+            var start = stream->start_time.ToTimeSpan(stream->time_base);
+            StartTime = start == TimeSpan.MinValue ? TimeSpan.Zero : start;
+        }
+
+        /// <summary>
+        /// Gets the codec name.
+        /// </summary>
+        public string CodecName { get; }
+
+        /// <summary>
+        /// Gets the codec identifier.
+        /// </summary>
+        public string CodecId { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the frames in the stream are interlaced.
+        /// </summary>
+        public bool IsInterlaced { get; }
+
+        /// <summary>
+        /// Gets the stream frame rate.
+        /// </summary>
+        public double FrameRate { get; }
+
+        /// <summary>
+        /// Gets the stream time base.
+        /// </summary>
+        public AVRational TimeBase { get; }
+
+        /// <summary>
+        /// Gets the video frame dimensions and pixel format.
+        /// </summary>
+        public Layout Dimensions { get; }
+
+        /// <summary>
+        /// Gets the stream duration.
+        /// </summary>
+        public TimeSpan Duration { get; }
+
+        /// <summary>
+        /// Gets the stream start time. Null if undefined.
+        /// </summary>
+        public TimeSpan? StartTime { get; }
+
+        /// <summary>
+        /// Gets the stream metadata.
+        /// </summary>
+        public ReadOnlyDictionary<string, string> Metadata { get; }
+
+        private static string FormatCodecId(AVCodecID id) => id.ToString().Remove(12).ToLower();
+    }
+}

--- a/FFMediaToolkit/src/Decoding/VideoStream.cs
+++ b/FFMediaToolkit/src/Decoding/VideoStream.cs
@@ -1,9 +1,6 @@
 ﻿namespace FFMediaToolkit.Decoding
 {
     using System;
-    using System.IO;
-    using System.Threading.Tasks;
-    using FFMediaToolkit.Common;
     using FFMediaToolkit.Common.Internal;
     using FFMediaToolkit.Decoding.Internal;
     using FFMediaToolkit.Graphics;

--- a/FFMediaToolkit/src/Decoding/VideoStream.cs
+++ b/FFMediaToolkit/src/Decoding/VideoStream.cs
@@ -67,6 +67,13 @@
         }
 
         /// <summary>
+        /// Reads the frame at the specified time from the video stream.
+        /// </summary>
+        /// <param name="targetTime">The frame time.</param>
+        /// <returns>The video frame.</returns>
+        public BitmapData ReadFrame(TimeSpan targetTime) => ReadFrame(targetTime.ToFrameNumber(Info.FrameRate));
+
+        /// <summary>
         /// Gets the next frame from the video stream.
         /// </summary>
         /// <returns>The video frame.</returns>

--- a/FFMediaToolkit/src/Decoding/VideoStream.cs
+++ b/FFMediaToolkit/src/Decoding/VideoStream.cs
@@ -1,0 +1,88 @@
+﻿namespace FFMediaToolkit.Decoding
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using FFMediaToolkit.Common;
+    using FFMediaToolkit.Common.Internal;
+    using FFMediaToolkit.Decoding.Internal;
+    using FFMediaToolkit.Graphics;
+    using FFMediaToolkit.Helpers;
+    using FFmpeg.AutoGen;
+
+    /// <summary>
+    /// Represents the video stream in a media file.
+    /// </summary>
+    public class VideoStream : IDisposable
+    {
+        private readonly InputStream<VideoFrame> stream;
+        private readonly VideoFrame frame;
+        private readonly Scaler scaler;
+        private readonly MediaOptions mediaOptions;
+
+        private readonly object syncLock = new object();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VideoStream"/> class.
+        /// </summary>
+        /// <param name="video">The video stream.</param>
+        /// <param name="options">The decoder settings.</param>
+        internal VideoStream(InputStream<VideoFrame> video, MediaOptions options)
+        {
+            stream = video;
+            mediaOptions = options;
+            frame = VideoFrame.CreateEmpty();
+            scaler = new Scaler();
+        }
+
+        /// <summary>
+        /// Gets the stream informations.
+        /// </summary>
+        public StreamInfo Info => stream.Info;
+
+        /// <summary>
+        /// Gets the current stream position in frames.
+        /// </summary>
+        public int FramePosition { get; private set; }
+
+        /// <summary>
+        /// Gets the next frame from the video file.
+        /// </summary>
+        /// <returns>The video frame.</returns>
+        public unsafe BitmapData ReadFrame()
+        {
+            lock (syncLock)
+            {
+                stream.Read(frame);
+                FramePosition++;
+
+                var targetLayout = GetTargetLayout();
+                var bitmap = PooledBitmap.Create(targetLayout.Width, targetLayout.Height, mediaOptions.VideoPixelFormat);
+
+                fixed (byte* ptr = bitmap.Data.Span)
+                {
+                    scaler.AVFrameToBitmap(frame.Pointer, frame.Layout, new IntPtr(ptr), targetLayout);
+                }
+
+                return bitmap;
+            }
+        }
+
+        /// <inheritdoc/>
+        void IDisposable.Dispose()
+        {
+            lock (syncLock)
+            {
+                stream.Dispose();
+                frame.Dispose();
+                scaler.Dispose();
+            }
+        }
+
+        private Layout GetTargetLayout()
+        {
+            var target = mediaOptions.TargetVideoSize ?? stream.Info.Dimensions.Size;
+            return new Layout((AVPixelFormat)mediaOptions.VideoPixelFormat, target);
+        }
+    }
+}

--- a/FFMediaToolkit/src/Graphics/Layout.cs
+++ b/FFMediaToolkit/src/Graphics/Layout.cs
@@ -1,11 +1,12 @@
 ﻿namespace FFMediaToolkit.Graphics
 {
     using System;
+    using System.Drawing;
     using FFMediaToolkit.Helpers;
     using FFmpeg.AutoGen;
 
     /// <summary>
-    /// Represents a bitmap configuration.
+    /// Represents bitmap size and pixel format.
     /// </summary>
     public struct Layout : IEquatable<Layout>
     {
@@ -18,8 +19,18 @@
         public Layout(AVPixelFormat pixelFormat, int width, int height)
         {
             PixelFormat = pixelFormat;
-            Width = width;
-            Height = height;
+            Size = new Size(width, height);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Layout"/> struct.
+        /// </summary>
+        /// <param name="pixelFormat">The pixel format.</param>
+        /// <param name="size">The size.</param>
+        public Layout(AVPixelFormat pixelFormat, Size size)
+        {
+            PixelFormat = pixelFormat;
+            Size = size;
         }
 
         /// <summary>
@@ -30,12 +41,17 @@
         /// <summary>
         /// Gets the image width.
         /// </summary>
-        public int Width { get; }
+        public int Width => Size.Width;
 
         /// <summary>
         /// Gets the image height.
         /// </summary>
-        public int Height { get; }
+        public int Height => Size.Height;
+
+        /// <summary>
+        /// Gets the image size.
+        /// </summary>
+        public Size Size { get; }
 
         /// <summary>
         /// Gets the image line size.
@@ -63,13 +79,13 @@
         /// </summary>
         /// <param name="other">The other <see cref="Layout"/> object to compare.</param>
         /// <returns><see langword="true"/> if equal, otherwise <see langword="false"/>.</returns>
-        public bool SizeEquals(Layout other) => Width == other.Width && Height == other.Height;
+        public bool SizeEquals(Layout other) => Size == other.Size;
 
         /// <inheritdoc/>
         public override bool Equals(object obj) => obj is Layout layout && Equals(layout);
 
         /// <inheritdoc/>
-        public bool Equals(Layout other) => PixelFormat == other.PixelFormat && Width == other.Width && Height == other.Height;
+        public bool Equals(Layout other) => PixelFormat == other.PixelFormat && Size == other.Size;
 
         /// <inheritdoc/>
         public override int GetHashCode()

--- a/FFMediaToolkit/src/Helpers/Extensions.cs
+++ b/FFMediaToolkit/src/Helpers/Extensions.cs
@@ -37,6 +37,14 @@
         }
 
         /// <summary>
+        /// Converts the frame number to a <see cref="TimeSpan"/>.
+        /// </summary>
+        /// <param name="frameNumber">The frame number.</param>
+        /// <param name="fps">The stream frame rate.</param>
+        /// <returns>The converted <see cref="TimeSpan"/>.</returns>
+        public static TimeSpan ToTimeSpan(this int frameNumber, double fps) => TimeSpan.FromMilliseconds(frameNumber * (1000 / fps));
+
+        /// <summary>
         /// Converts this <see cref="TimeSpan"/> to a frame number based on the specified <paramref name="timeBase"/>.
         /// </summary>
         /// <param name="time">The time.</param>

--- a/FFMediaToolkit/src/Helpers/Extensions.cs
+++ b/FFMediaToolkit/src/Helpers/Extensions.cs
@@ -45,13 +45,13 @@
         public static TimeSpan ToTimeSpan(this int frameNumber, double fps) => TimeSpan.FromMilliseconds(frameNumber * (1000 / fps));
 
         /// <summary>
-        /// Converts this <see cref="TimeSpan"/> to a frame number based on the specified <paramref name="timeBase"/>.
+        /// Converts this <see cref="TimeSpan"/> to a frame number based on the specified frame rate/>.
         /// </summary>
         /// <param name="time">The time.</param>
-        /// <param name="timeBase">The stream time base.</param>
+        /// <param name="framerate">The stream frame rate.</param>
         /// <returns>The frame number.</returns>
-        public static int ToFrameNumber(this TimeSpan time, AVRational timeBase)
-            => (int)(time.Milliseconds / timeBase.ToDouble());
+        public static int ToFrameNumber(this TimeSpan time, double framerate)
+            => (int)(time.Milliseconds / framerate);
 
         /// <summary>
         /// Converts this frame number to a timestamp in the <paramref name="timeBase"/> units.

--- a/FFMediaToolkit/src/Helpers/Extensions.cs
+++ b/FFMediaToolkit/src/Helpers/Extensions.cs
@@ -55,6 +55,15 @@
             => timeBase.den == 0 ? 0 : timeBase.num * frameNumber / timeBase.den;
 
         /// <summary>
+        /// Converts the <see cref="TimeSpan"/> to a timestamp in the <paramref name="timeBase"/> units.
+        /// </summary>
+        /// <param name="time">The time.</param>
+        /// <param name="timeBase">The stream time base.</param>
+        /// <returns>The timestamp.</returns>
+        public static long ToTimestamp(this TimeSpan time, AVRational timeBase)
+            => timeBase.num == 0 ? 0 : Convert.ToInt64(time.TotalSeconds * timeBase.den / timeBase.num);
+
+        /// <summary>
         /// Gets the type of content in the <see cref="AVFrame"/>.
         /// </summary>
         /// <param name="frame">The <see cref="AVFrame"/>.</param>

--- a/FFMediaToolkit/src/Helpers/StringConverter.cs
+++ b/FFMediaToolkit/src/Helpers/StringConverter.cs
@@ -15,7 +15,7 @@
         /// </summary>
         /// <param name="pointer">A pointer to the umanaged string.</param>
         /// <returns>The converted string.</returns>
-        public static string StringFromUtf8(IntPtr pointer)
+        public static string Utf8ToString(this IntPtr pointer)
         {
             var lenght = 0;
 
@@ -41,7 +41,7 @@
             var buffer = stackalloc byte[bufferSize];
             ffmpeg.av_strerror(errorCode, buffer, bufferSize);
 
-            var message = StringFromUtf8((IntPtr)buffer);
+            var message = new IntPtr(buffer).Utf8ToString();
             return message;
         }
     }


### PR DESCRIPTION
Currently there are no public classes for decoding video files. This PR aims to create the `MediaFile` and `VideoStream` classes in the `FFMediaToolkit.Decoding` namespace.