### PR TITLE
Duration fix

### DIFF
--- a/FFMediaToolkit/src/Decoding/Internal/InputStream{TFrame}.cs
+++ b/FFMediaToolkit/src/Decoding/Internal/InputStream{TFrame}.cs
@@ -26,7 +26,7 @@
             PacketQueue = new ObservableQueue<MediaPacket>();
 
             Type = typeof(TFrame) == typeof(VideoFrame) ? MediaType.Video : MediaType.None;
-            Info = new StreamInfo(stream);
+            Info = new StreamInfo(stream, owner);
         }
 
         /// <summary>

--- a/FFMediaToolkit/src/Decoding/StreamInfo.cs
+++ b/FFMediaToolkit/src/Decoding/StreamInfo.cs
@@ -1,12 +1,10 @@
-﻿using System.ComponentModel;
-using FFMediaToolkit.Decoding.Internal;
-
-namespace FFMediaToolkit.Decoding
+﻿namespace FFMediaToolkit.Decoding
 {
     using System;
     using System.Collections.ObjectModel;
     using System.Drawing;
     using FFMediaToolkit.Common;
+    using FFMediaToolkit.Decoding.Internal;
     using FFMediaToolkit.Helpers;
     using FFmpeg.AutoGen;
 

--- a/FFMediaToolkit/src/Decoding/StreamInfo.cs
+++ b/FFMediaToolkit/src/Decoding/StreamInfo.cs
@@ -27,13 +27,16 @@ namespace FFMediaToolkit.Decoding
             CodecName = ffmpeg.avcodec_get_name(codec->codec_id);
             CodecId = FormatCodecId(codec->codec_id);
             Index = stream->index;
-            IsInterlaced = codec->field_order != AVFieldOrder.AV_FIELD_PROGRESSIVE && codec->field_order != AVFieldOrder.AV_FIELD_UNKNOWN;
+            IsInterlaced = codec->field_order != AVFieldOrder.AV_FIELD_PROGRESSIVE &&
+                           codec->field_order != AVFieldOrder.AV_FIELD_UNKNOWN;
             FrameSize = new Size(codec->width, codec->height);
             PixelFormat = codec->pix_fmt;
             TimeBase = stream->time_base;
             RFrameRate = stream->r_frame_rate;
             FrameRate = RFrameRate.ToDouble();
-            Duration = TimeSpan.FromTicks(container.Pointer->duration * 10);
+            Duration = stream->duration >= 0
+                ? stream->duration.ToTimeSpan(stream->time_base)
+                : TimeSpan.FromTicks(container.Pointer->duration * 10);
             var start = stream->start_time.ToTimeSpan(stream->time_base);
             StartTime = start == TimeSpan.MinValue ? TimeSpan.Zero : start;
             FrameCount = Duration.ToFrameNumber(RFrameRate);

--- a/FFMediaToolkit/src/Decoding/StreamInfo.cs
+++ b/FFMediaToolkit/src/Decoding/StreamInfo.cs
@@ -1,4 +1,7 @@
-﻿namespace FFMediaToolkit.Decoding
+﻿using System.ComponentModel;
+using FFMediaToolkit.Decoding.Internal;
+
+namespace FFMediaToolkit.Decoding
 {
     using System;
     using System.Collections.ObjectModel;
@@ -19,10 +22,6 @@
         /// <param name="container">The input container.</param>
         internal unsafe StreamInfo(AVStream* stream, InputContainer container)
         {
-            Container = container;
-            var avChapter = container.Pointer->chapters[0];
-            var avDictionary = avChapter->metadata[0];
-
             var codec = stream->codec;
             Metadata = new ReadOnlyDictionary<string, string>(FFDictionary.ToDictionary(stream->metadata));
             CodecName = ffmpeg.avcodec_get_name(codec->codec_id);
@@ -34,7 +33,7 @@
             TimeBase = stream->time_base;
             RFrameRate = stream->r_frame_rate;
             FrameRate = RFrameRate.ToDouble();
-            Duration = TimeSpan.FromTicks(Container.Pointer->duration * 10);
+            Duration = TimeSpan.FromTicks(container.Pointer->duration * 10);
             var start = stream->start_time.ToTimeSpan(stream->time_base);
             StartTime = start == TimeSpan.MinValue ? TimeSpan.Zero : start;
             FrameCount = Duration.ToFrameNumber(RFrameRate);


### PR DESCRIPTION
This will use AVContext's duration instead of the stream duration.

It should be noted that this might not work on other files and must be tested.