### PR TITLE
Fix failure to decode on Mac OS X

### DIFF
--- a/FFMediaToolkit/src/Decoding/Internal/InputStream{TFrame}.cs
+++ b/FFMediaToolkit/src/Decoding/Internal/InputStream{TFrame}.cs
@@ -134,7 +134,7 @@
                 DecodePacket(); // Gets the next packet and sends it to the decoder.
                 error = ffmpeg.avcodec_receive_frame(CodecPointer, decodedFrame.Pointer); // Tries to decode frame from the packets.
             }
-            while (error == -ffmpeg.EAGAIN); // The EAGAIN code means that the frame decoding has not been completed and more packets are needed.
+            while (error == -ffmpeg.EAGAIN || error == -35); // The EAGAIN code means that the frame decoding has not been completed and more packets are needed.
 
             error.ThrowIfError("An error ocurred while decoding the frame.");
         }


### PR DESCRIPTION
Without this change, attempting to call `MediaFile.Video.ReadNextFrame()` or `ReadFrame(int)` always resulted in an exception with error number -35 "The device is temporarily unavailable". Adding a check for this value to the while loop fixes it. I don't know what -35 means vs EAGAIN, but this change gets everything working on Mac.

Great library - thank you for publishing it!