### PR TITLE
Add UYVY422 pixel format support.

### DIFF
--- a/FFMediaToolkit/src/Graphics/ImageData.cs
+++ b/FFMediaToolkit/src/Graphics/ImageData.cs
@@ -166,6 +166,8 @@
                     return 3;
                 case ImagePixelFormat.Argb32:
                     return 4;
+                case ImagePixelFormat.Uyvy422:
+                    return 2;
                 default:
                     return 0;
             }

--- a/FFMediaToolkit/src/Graphics/ImagePixelFormat.cs
+++ b/FFMediaToolkit/src/Graphics/ImagePixelFormat.cs
@@ -26,5 +26,10 @@
         /// Represents a ARGB(with alpha channel) 32bpp bitmap pixel format.
         /// </summary>
         Argb32 = AVPixelFormat.AV_PIX_FMT_ARGB,
+
+        /// <summary>
+        /// Represents a UYVY422 pixel format.
+        /// </summary>
+        Uyvy422 = AVPixelFormat.AV_PIX_FMT_UYVY422,
     }
 }


### PR DESCRIPTION
I have a capture card that feeds me raw pixel data in YUV422 (or more specifically, UYVY422) format. With this change, I can pass it straight through without an intermediate conversion to RGB.