### PR TITLE
Change VideoEncoderSettings.Framerate to an AVRational instead of int

### DIFF
--- a/FFMediaToolkit/Encoding/Internal/OutputStreamFactory.cs
+++ b/FFMediaToolkit/Encoding/Internal/OutputStreamFactory.cs
@@ -33,7 +33,7 @@
                 throw new InvalidOperationException($"The {codecId} encoder doesn't support video!");
 
             var videoStream = ffmpeg.avformat_new_stream(container.Pointer, codec);
-            videoStream->time_base = new AVRational { num = 1, den = config.Framerate };
+            videoStream->time_base = config.Framerate;
             var codecContext = videoStream->codec;
             codecContext->codec_id = codecId;
             codecContext->codec_type = AVMediaType.AVMEDIA_TYPE_VIDEO;

--- a/FFMediaToolkit/Encoding/VideoEncoderSettings.cs
+++ b/FFMediaToolkit/Encoding/VideoEncoderSettings.cs
@@ -21,7 +21,7 @@
         {
             VideoWidth = width;
             VideoHeight = height;
-            Framerate = framerate;
+            Framerate = new AVRational { num = framerate, den = 1 };
             Codec = codec;
             CodecOptions = new Dictionary<string, string>();
         }
@@ -56,7 +56,7 @@
         /// <summary>
         /// Gets or sets video frame rate (FPS) value. The default value is 30 frames/s.
         /// </summary>
-        public int Framerate { get; set; }
+        public AVRational Framerate { get; set; }
 
         /// <summary>
         /// Gets or sets the Constant Rate Factor. It supports only H.264 and H.265 codecs.

--- a/FFMediaToolkit/Encoding/VideoOutputStream.cs
+++ b/FFMediaToolkit/Encoding/VideoOutputStream.cs
@@ -49,7 +49,7 @@
         /// <summary>
         /// Gets the current duration of this stream.
         /// </summary>
-        public TimeSpan CurrentDuration => FramesCount.ToTimeSpan(Configuration.Framerate);
+        public TimeSpan CurrentDuration => FramesCount.ToTimeSpan((double)Configuration.Framerate.num / (double)Configuration.Framerate.den);
 
         /// <summary>
         /// Writes the specified bitmap to the video stream as the next frame.


### PR DESCRIPTION
This allows the user to specify non-integer framerates (e.g., 29.97).