### PR TITLE
Avoid memory leaks by wiping internally allocated data from packet af…

### DIFF
--- a/FFMediaToolkit/Decoding/Internal/Decoder{TFrame}.cs
+++ b/FFMediaToolkit/Decoding/Internal/Decoder{TFrame}.cs
@@ -106,6 +106,7 @@
             else
             {
                 result.ThrowIfError("Cannot send a packet to the decoder.");
+                pkt.Wipe();
             }
         }
     }

--- a/FFMediaToolkit/Decoding/Internal/InputContainer.cs
+++ b/FFMediaToolkit/Decoding/Internal/InputContainer.cs
@@ -57,11 +57,13 @@
             if (canReusePacket)
             {
                 canReusePacket = false;
+                if (packet.StreamIndex != streamIndex)
+                    packet.Wipe();
+                else
+                    return packet;
             }
-            else
-            {
-                GetPacketFromStream(streamIndex);
-            }
+
+            GetPacketFromStream(streamIndex);
 
             return packet;
         }
@@ -132,8 +134,12 @@
             do
             {
                 ReadPacket();
+                if (packet.StreamIndex != streamIndex)
+                    packet.Wipe();
+                else
+                    break;
             }
-            while (packet.StreamIndex != streamIndex);
-        }
+            while (true);
+         }
     }
 }


### PR DESCRIPTION
…ter it gets used (or skipped).

I suppose memory allocations and deallocations could be avoided by using av_new_packet with/instead of av_packet_alloc, but I didn't test that yet and I'm not sure what buffer sizes it would have to use.