### PR TITLE
Improved AV Reading/Writing

### DIFF
--- a/FFMediaToolkit/Audio/AudioData.cs
+++ b/FFMediaToolkit/Audio/AudioData.cs
@@ -34,9 +34,51 @@
         /// </summary>
         /// <param name="channel">The index of audio channel that should be retrieved, allowed range: [0..<see cref="NumChannels"/>).</param>
         /// <returns>The span with samples in range of [-1.0, ..., 1.0].</returns>
-        public ReadOnlySpan<float> GetChannelData(uint channel)
+        public Span<float> GetChannelData(uint channel)
         {
             return frame.GetChannelData(channel);
+        }
+
+        /// <summary>
+        /// Copies raw multichannel audio data from this frame to a heap allocated array.
+        /// </summary>
+        /// <returns>
+        /// The span with <see cref="NumChannels"/> rows and <see cref="NumSamples"/> columns;
+        /// samples in range of [-1.0, ..., 1.0].
+        /// </returns>
+        public float[][] GetSampleData()
+        {
+            return frame.GetSampleData();
+        }
+
+        /// <summary>
+        /// Updates the specified channel of this audio frame with the given sample data.
+        /// </summary>
+        /// <param name="samples">An array of samples with length <see cref="NumSamples"/>.</param>
+        /// <param name="channel">The index of audio channel that should be updated, allowed range: [0..<see cref="NumChannels"/>).</param>
+        public void UpdateChannelData(float[] samples, uint channel)
+        {
+            frame.UpdateChannelData(samples, channel);
+        }
+
+        /// <summary>
+        /// Updates this audio frame with the specified multi-channel sample data.
+        /// </summary>
+        /// <param name="samples">
+        /// A 2D jagged array of multi-channel sample data
+        /// with <see cref="NumChannels"/> rows and <see cref="NumSamples"/> columns.
+        /// </param>
+        public void UpdateFromSampleData(float[][] samples)
+        {
+            frame.UpdateFromSampleData(samples);
+        }
+
+        /// <summary>
+        /// Releases all unmanaged resources associated with this instance.
+        /// </summary>
+        public void Dispose()
+        {
+            frame.Dispose();
         }
     }
 }

--- a/FFMediaToolkit/Audio/SampleFormat.cs
+++ b/FFMediaToolkit/Audio/SampleFormat.cs
@@ -1,0 +1,60 @@
+﻿namespace FFMediaToolkit.Audio
+{
+    using FFmpeg.AutoGen;
+
+    /// <summary>
+    /// Enumerates common audio sample formats supported by FFmpeg.
+    /// </summary>
+    public enum SampleFormat
+    {
+        /// <summary>
+        /// Unsupported/Unknown.
+        /// </summary>
+        None = AVSampleFormat.AV_SAMPLE_FMT_NONE,
+
+        /// <summary>
+        /// Unsigned 8-bit integer.
+        /// </summary>
+        UnsignedByte = AVSampleFormat.AV_SAMPLE_FMT_U8,
+
+        /// <summary>
+        /// Signed 16-bit integer.
+        /// </summary>
+        SignedWord = AVSampleFormat.AV_SAMPLE_FMT_S16,
+
+        /// <summary>
+        /// Signed 32-bit integer.
+        /// </summary>
+        SignedDWord = AVSampleFormat.AV_SAMPLE_FMT_S32,
+
+        /// <summary>
+        /// Single precision floating point.
+        /// </summary>
+        Single = AVSampleFormat.AV_SAMPLE_FMT_FLT,
+
+        /// <summary>
+        /// Double precision floating point.
+        /// </summary>
+        Double = AVSampleFormat.AV_SAMPLE_FMT_DBL,
+
+        /// <summary>
+        /// Signed 16-bit integer (planar).
+        /// </summary>
+        SignedWordP = AVSampleFormat.AV_SAMPLE_FMT_S16P,
+
+        /// <summary>
+        /// Signed 32-bit integer (planar).
+        /// </summary>
+        SignedDWordP = AVSampleFormat.AV_SAMPLE_FMT_S32P,
+
+        /// <summary>
+        /// Single precision floating point (planar).
+        /// </summary>
+        SingleP = AVSampleFormat.AV_SAMPLE_FMT_FLTP,
+
+        /// <summary>
+        /// Double precision floating point (planar).
+        /// </summary>
+        DoubleP = AVSampleFormat.AV_SAMPLE_FMT_DBLP,
+    }
+}

--- a/FFMediaToolkit/Common/ContainerMetadata.cs
+++ b/FFMediaToolkit/Common/ContainerMetadata.cs
@@ -1,7 +1,7 @@
 ﻿namespace FFMediaToolkit.Common
 {
-    using FFmpeg.AutoGen;
     using System.Collections.Generic;
+    using FFmpeg.AutoGen;
 
     /// <summary>
     /// Represents multimedia file metadata info.

--- a/FFMediaToolkit/Common/Internal/AudioFrame.cs
+++ b/FFMediaToolkit/Common/Internal/AudioFrame.cs
@@ -1,4 +1,5 @@
-﻿namespace FFMediaToolkit.Common.Internal {
+﻿namespace FFMediaToolkit.Common.Internal
+{
     using System;
     using FFMediaToolkit.Helpers;
     using FFmpeg.AutoGen;
@@ -40,7 +41,7 @@
         /// <summary>
         /// Gets the audio sample format.
         /// </summary>
-        public AVSampleFormat SampleFormat => Pointer != null ? (AVSampleFormat) Pointer->format : AVSampleFormat.AV_SAMPLE_FMT_NONE;
+        public AVSampleFormat SampleFormat => Pointer != null ? (AVSampleFormat)Pointer->format : AVSampleFormat.AV_SAMPLE_FMT_NONE;
 
         /// <summary>
         /// Creates an audio frame with given dimensions and allocates a buffer for it.

--- a/FFMediaToolkit/Common/Internal/AudioFrame.cs
+++ b/FFMediaToolkit/Common/Internal/AudioFrame.cs
@@ -1,6 +1,7 @@
 ﻿namespace FFMediaToolkit.Common.Internal
 {
     using System;
+    using FFMediaToolkit.Audio;
     using FFMediaToolkit.Helpers;
     using FFmpeg.AutoGen;
 
@@ -34,6 +35,11 @@
         public int NumSamples => Pointer != null ? Pointer->nb_samples : default;
 
         /// <summary>
+        /// Gets the sample rate.
+        /// </summary>
+        public int SampleRate => Pointer != null ? Pointer->sample_rate : default;
+
+        /// <summary>
         /// Gets the number of channels.
         /// </summary>
         public int NumChannels => Pointer != null ? Pointer->channels : default;
@@ -41,20 +47,31 @@
         /// <summary>
         /// Gets the audio sample format.
         /// </summary>
-        public AVSampleFormat SampleFormat => Pointer != null ? (AVSampleFormat)Pointer->format : AVSampleFormat.AV_SAMPLE_FMT_NONE;
+        public SampleFormat SampleFormat => Pointer != null ? (SampleFormat)Pointer->format : SampleFormat.None;
+
+        /// <summary>
+        /// Gets the channel layout.
+        /// </summary>
+        internal long ChannelLayout => Pointer != null ? (long)Pointer->channel_layout : default;
 
         /// <summary>
         /// Creates an audio frame with given dimensions and allocates a buffer for it.
         /// </summary>
-        /// <param name="num_samples">The number of samples in the audio frame.</param>
+        /// <param name="sample_rate">The sample rate of the audio frame.</param>
         /// <param name="num_channels">The number of channels in the audio frame.</param>
+        /// <param name="num_samples">The number of samples in the audio frame.</param>
+        /// <param name="channel_layout">The channel layout to be used by the audio frame.</param>
         /// <param name="sampleFormat">The audio sample format.</param>
         /// <returns>The new audio frame.</returns>
-        public static AudioFrame Create(int num_samples, int num_channels, AVSampleFormat sampleFormat)
+        public static AudioFrame Create(int sample_rate, int num_channels, int num_samples, long channel_layout, SampleFormat sampleFormat)
         {
             var frame = ffmpeg.av_frame_alloc();
-            frame->nb_samples = num_samples;
+
+            frame->sample_rate = sample_rate;
             frame->channels = num_channels;
+
+            frame->nb_samples = num_samples;
+            frame->channel_layout = (ulong)channel_layout;
             frame->format = (int)sampleFormat;
 
             ffmpeg.av_frame_get_buffer(frame, 32);
@@ -73,9 +90,94 @@
         /// </summary>
         /// <param name="channel">The index of audio channel that should be retrieved, allowed range: [0..<see cref="NumChannels"/>).</param>
         /// <returns>The span with samples in range of [-1.0, ..., 1.0].</returns>
-        public ReadOnlySpan<float> GetChannelData(uint channel)
+        public Span<float> GetChannelData(uint channel)
         {
-            return new ReadOnlySpan<float>(Pointer->data[channel], NumSamples);
+            if (SampleFormat != SampleFormat.SingleP)
+                throw new Exception("Cannot extract channel data from an AudioFrame with a SampleFormat not equal to SampleFormat.SingleP");
+            return new Span<float>(Pointer->data[channel], NumSamples);
+        }
+
+        /// <summary>
+        /// Copies raw multichannel audio data from this frame to a heap allocated array.
+        /// </summary>
+        /// <returns>
+        /// The span with <see cref="NumChannels"/> rows and <see cref="NumSamples"/> columns;
+        /// samples in range of [-1.0, ..., 1.0].
+        /// </returns>
+        public float[][] GetSampleData()
+        {
+            if (SampleFormat != SampleFormat.SingleP)
+                throw new Exception("Cannot extract sample data from an AudioFrame with a SampleFormat not equal to SampleFormat.SingleP");
+
+            var samples = new float[NumChannels][];
+
+            for (uint ch = 0; ch < NumChannels; ch++)
+            {
+                samples[ch] = new float[NumSamples];
+
+                var channelData = GetChannelData(ch);
+                var sampleData = new Span<float>(samples[ch], 0, NumSamples);
+
+                channelData.CopyTo(sampleData);
+            }
+
+            return samples;
+        }
+
+        /// <summary>
+        /// Updates the specified channel of this audio frame with the given sample data.
+        /// </summary>
+        /// <param name="samples">An array of samples with length <see cref="NumSamples"/>.</param>
+        /// <param name="channel">The index of audio channel that should be updated, allowed range: [0..<see cref="NumChannels"/>).</param>
+        public void UpdateChannelData(float[] samples, uint channel)
+        {
+            if (SampleFormat != SampleFormat.SingleP)
+                throw new Exception("Cannot update channel data of an AudioFrame with a SampleFormat not equal to SampleFormat.SingleP");
+
+            var frameData = GetChannelData(channel);
+            var sampleData = new Span<float>(samples, 0, NumSamples);
+
+            sampleData.CopyTo(frameData);
+        }
+
+        /// <summary>
+        /// Updates this audio frame with the specified multi-channel sample data.
+        /// </summary>
+        /// <param name="samples">
+        /// A 2D jagged array of multi-channel sample data
+        /// with <see cref="NumChannels"/> rows and <see cref="NumSamples"/> columns.
+        /// </param>
+        public void UpdateFromSampleData(float[][] samples)
+        {
+            if (SampleFormat != SampleFormat.SingleP)
+                throw new Exception("Cannot update sample data of an AudioFrame with a SampleFormat not equal to SampleFormat.SingleP");
+
+            for (uint ch = 0; ch < NumChannels; ch++)
+            {
+                var newData = new Span<float>(samples[ch], 0, NumSamples);
+                var frameData = GetChannelData(ch);
+                newData.CopyTo(frameData);
+            }
+        }
+
+        /// <summary>
+        /// Updates this audio frame with the specified audio data.
+        /// (<see cref="AudioData.NumSamples"/> and <see cref="AudioData.NumChannels"/>
+        /// should match the respective values for this instance!).
+        /// </summary>
+        /// <param name="audioData">The audio data.</param>
+        public void UpdateFromAudioData(AudioData audioData)
+        {
+            if (SampleFormat != SampleFormat.SingleP)
+                throw new Exception("Cannot update data of an AudioFrame with a SampleFormat not equal to SampleFormat.SingleP");
+
+            for (uint ch = 0; ch < NumChannels; ch++)
+            {
+                var newData = audioData.GetChannelData(ch);
+                var currData = GetChannelData(ch);
+
+                newData.CopyTo(currData);
+            }
         }
 
         /// <inheritdoc/>

--- a/FFMediaToolkit/Common/Internal/ImageConverter.cs
+++ b/FFMediaToolkit/Common/Internal/ImageConverter.cs
@@ -58,14 +58,12 @@
         /// </summary>
         /// <param name="videoFrame">The video frame to convert.</param>
         /// <param name="destination">The destination <see cref="ImageData"/>.</param>
-        internal void AVFrameToBitmap(VideoFrame videoFrame, ImageData destination)
+        /// <param name="stride">Size of the single bitmap row.</param>
+        internal void AVFrameToBitmap(VideoFrame videoFrame, byte* destination, int stride)
         {
-            fixed (byte* ptr = destination.Data)
-            {
-                var data = new byte*[4] { ptr, null, null, null };
-                var linesize = new int[4] { destination.Stride, 0, 0, 0 };
-                ffmpeg.sws_scale(Pointer, videoFrame.Pointer->data, videoFrame.Pointer->linesize, 0, videoFrame.Layout.Height, data, linesize);
-            }
+            var data = new byte*[4] { destination, null, null, null };
+            var linesize = new int[4] { stride, 0, 0, 0 };
+            ffmpeg.sws_scale(Pointer, videoFrame.Pointer->data, videoFrame.Pointer->linesize, 0, videoFrame.Layout.Height, data, linesize);
         }
 
         /// <inheritdoc/>

--- a/FFMediaToolkit/Common/Internal/MediaPacket.cs
+++ b/FFMediaToolkit/Common/Internal/MediaPacket.cs
@@ -48,12 +48,11 @@
         /// <summary>
         /// Allocates a new empty packet.
         /// </summary>
-        /// <param name="streamIndex">The packet stream index.</param>
         /// <returns>The new <see cref="MediaPacket"/>.</returns>
-        public static MediaPacket AllocateEmpty(int streamIndex)
+        public static MediaPacket AllocateEmpty()
         {
             var packet = ffmpeg.av_packet_alloc();
-            packet->stream_index = streamIndex;
+            packet->stream_index = -1;
             return new MediaPacket(packet);
         }
 

--- a/FFMediaToolkit/Common/Internal/VideoFrame.cs
+++ b/FFMediaToolkit/Common/Internal/VideoFrame.cs
@@ -77,13 +77,20 @@
         /// </summary>
         /// <param name="converter">A <see cref="ImageConverter"/> object, used for caching the FFMpeg <see cref="SwsContext"/> when converting many frames of the same video.</param>
         /// <param name="targetFormat">The output bitmap pixel format.</param>
+        /// /// <param name="targetSize">The output bitmap size.</param>
         /// <returns>A <see cref="ImageData"/> instance containing converted bitmap data.</returns>
-        public ImageData ToBitmap(ImageConverter converter, ImagePixelFormat targetFormat)
+        public ImageData ToBitmap(ImageConverter converter, ImagePixelFormat targetFormat, Size targetSize)
         {
-            var bitmap = ImageData.CreatePooled(Layout, targetFormat);
-            converter.AVFrameToBitmap(this, bitmap);
+            var bitmap = ImageData.CreatePooled(targetSize, targetFormat); // Rents memory for the output bitmap.
+            fixed (byte* ptr = bitmap.Data)
+            {
+                // Converts the raw video frame using the given size and pixel format and writes it to the ImageData bitmap.
+                converter.AVFrameToBitmap(this, ptr, bitmap.Stride);
+            }
+
             return bitmap;
         }
+
 
         /// <inheritdoc/>
         internal override unsafe void Update(AVFrame* newFrame)

--- a/FFMediaToolkit/Common/Internal/VideoFrame.cs
+++ b/FFMediaToolkit/Common/Internal/VideoFrame.cs
@@ -91,7 +91,6 @@
             return bitmap;
         }
 
-
         /// <inheritdoc/>
         internal override unsafe void Update(AVFrame* newFrame)
         {

--- a/FFMediaToolkit/Common/MediaType.cs
+++ b/FFMediaToolkit/Common/MediaType.cs
@@ -1,9 +1,9 @@
-﻿namespace FFMediaToolkit.Common.Internal
+﻿namespace FFMediaToolkit.Common
 {
     /// <summary>
     /// Represents the multimedia stream types.
     /// </summary>
-    internal enum MediaType
+    public enum MediaType
     {
         /// <summary>
         /// Other media type not supported by the FFMediaToolkit.

--- a/FFMediaToolkit/Decoding/AudioStream.cs
+++ b/FFMediaToolkit/Decoding/AudioStream.cs
@@ -1,125 +1,93 @@
 ﻿namespace FFMediaToolkit.Decoding
 {
     using System;
+    using System.IO;
     using FFMediaToolkit.Audio;
     using FFMediaToolkit.Common.Internal;
     using FFMediaToolkit.Decoding.Internal;
-    using FFMediaToolkit.Helpers;
 
     /// <summary>
     /// Represents an audio stream in the <see cref="MediaFile"/>.
     /// </summary>
-    public class AudioStream : IDisposable
+    public class AudioStream : MediaStream
     {
-        private readonly Decoder stream;
-        private readonly AudioFrame frame;
-        private readonly MediaOptions mediaOptions;
-
-        private readonly object syncLock = new object();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AudioStream"/> class.
         /// </summary>
-        /// <param name="audio">The Audio stream.</param>
+        /// <param name="stream">The audio stream.</param>
         /// <param name="options">The decoder settings.</param>
-        internal AudioStream(Decoder audio, MediaOptions options)
+        internal AudioStream(Decoder stream, MediaOptions options)
+            : base(stream, options)
         {
-            stream = audio;
-            mediaOptions = options;
-            frame = AudioFrame.CreateEmpty();
         }
 
         /// <summary>
         /// Gets informations about this stream.
         /// </summary>
-        public AudioStreamInfo Info => (AudioStreamInfo)stream.Info;
+        public new AudioStreamInfo Info => base.Info as AudioStreamInfo;
 
         /// <summary>
-        /// Gets the index of the next frame in the Audio stream.
+        /// Reads the next frame from the audio stream.
         /// </summary>
-        public int FramePosition { get; private set; }
-
-        /// <summary>
-        /// Gets the timestamp of the next frame in the Audio stream.
-        /// </summary>
-        public TimeSpan Position => FramePosition.ToTimeSpan(Info.AvgFrameRate);
-
-        /// <summary>
-        /// Reads the specified audio frame (chunk of audio samples sized by ffmedia settings).
-        /// </summary>
-        /// <param name="frameNumber">The frame index (zero-based number).</param>
-        /// <returns>The decoded audio frame.</returns>
-        public AudioData ReadFrame(int frameNumber)
+        /// <returns>The decoded audio data.</returns>
+        public new AudioData GetNextFrame()
         {
-            lock (syncLock)
+            var frame = base.GetNextFrame() as AudioFrame;
+            return new AudioData(frame);
+        }
+
+        /// <summary>
+        /// Reads the next frame from the audio stream.
+        /// A <see langword="false"/> return value indicates that reached end of stream.
+        /// The method throws exception if another error has occurred.
+        /// </summary>
+        /// <param name="data">The decoded audio data.</param>
+        /// <returns><see langword="false"/> if reached end of the stream.</returns>
+        public bool TryGetNextFrame(out AudioData data)
+        {
+            try
             {
-                frameNumber = frameNumber.Clamp(0, Info.NumberOfFrames.Value != 0 ? Info.NumberOfFrames.Value - 1 : int.MaxValue);
-
-                if (frameNumber == FramePosition)
-                {
-                    return GetNextFrameData();
-                }
-                else if (frameNumber == FramePosition - 1)
-                {
-                    return new AudioData(stream.RecentlyDecodedFrame as AudioFrame);
-                }
-                else
-                {
-                    var frame = SeekToFrame(frameNumber);
-                    FramePosition = frameNumber + 1;
-
-                    return new AudioData(frame);
-                }
+                data = GetNextFrame();
+                return true;
+            }
+            catch (EndOfStreamException)
+            {
+                data = default;
+                return false;
             }
         }
 
         /// <summary>
-        /// Reads the audio frame found at the specified timestamp.
+        /// Reads the video frame found at the specified timestamp.
         /// </summary>
-        /// <param name="targetTime">The frame timestamp.</param>
-        /// <returns>The decoded audio frame.</returns>
-        public AudioData ReadFrame(TimeSpan targetTime) => ReadFrame((int)(targetTime.TotalSeconds * Info.AvgFrameRate));
+        /// <param name="time">The frame timestamp.</param>
+        /// <returns>The decoded video frame.</returns>
+        public new AudioData GetFrame(TimeSpan time)
+        {
+            var frame = base.GetFrame(time) as AudioFrame;
+            return new AudioData(frame);
+        }
 
         /// <summary>
-        /// Reads the next frame from this stream.
+        /// Reads the audio data found at the specified timestamp.
+        /// A <see langword="false"/> return value indicates that reached end of stream.
+        /// The method throws exception if another error has occurred.
         /// </summary>
-        /// <returns>The decoded audio frame.</returns>
-        public AudioData ReadNextFrame()
+        /// <param name="time">The frame timestamp.</param>
+        /// <param name="data">The decoded audio data.</param>
+        /// <returns><see langword="false"/> if reached end of the stream.</returns>
+        public bool TryGetFrame(TimeSpan time, out AudioData data)
         {
-            lock (syncLock)
+            try
             {
-              return GetNextFrameData();
+                data = GetFrame(time);
+                return true;
             }
-        }
-
-        /// <inheritdoc/>
-        void IDisposable.Dispose()
-        {
-            lock (syncLock)
+            catch (EndOfStreamException)
             {
-                stream.Dispose();
-                frame.Dispose();
+                data = default;
+                return false;
             }
-        }
-
-        private AudioData GetNextFrameData()
-        {
-            var bmp = new AudioData(stream.GetNextFrame() as AudioFrame);
-            FramePosition++;
-            return bmp;
-        }
-
-        private AudioFrame SeekToFrame(int frameNumber)
-        {
-            var ts = frameNumber * Info.AvgNumSamplesPerFrame;
-
-            if (frameNumber < FramePosition || frameNumber > FramePosition + mediaOptions.AudioSeekThreshold)
-            {
-                stream.OwnerFile.SeekFile(ts, Info.Index);
-            }
-
-            stream.SkipFrames(ts);
-            return stream.RecentlyDecodedFrame as AudioFrame;
         }
     }
 }

--- a/FFMediaToolkit/Decoding/AudioStream.cs
+++ b/FFMediaToolkit/Decoding/AudioStream.cs
@@ -5,14 +5,13 @@
     using FFMediaToolkit.Common.Internal;
     using FFMediaToolkit.Decoding.Internal;
     using FFMediaToolkit.Helpers;
-    using FFmpeg.AutoGen;
 
     /// <summary>
     /// Represents an audio stream in the <see cref="MediaFile"/>.
     /// </summary>
     public class AudioStream : IDisposable
     {
-        private readonly Decoder<AudioFrame> stream;
+        private readonly Decoder stream;
         private readonly AudioFrame frame;
         private readonly MediaOptions mediaOptions;
 
@@ -23,7 +22,7 @@
         /// </summary>
         /// <param name="audio">The Audio stream.</param>
         /// <param name="options">The decoder settings.</param>
-        internal AudioStream(Decoder<AudioFrame> audio, MediaOptions options)
+        internal AudioStream(Decoder audio, MediaOptions options)
         {
             stream = audio;
             mediaOptions = options;
@@ -54,7 +53,7 @@
         {
             lock (syncLock)
             {
-                frameNumber = frameNumber.Clamp(0, Info.FrameCount != 0 ? Info.FrameCount - 1 : int.MaxValue);
+                frameNumber = frameNumber.Clamp(0, Info.NumberOfFrames.Value != 0 ? Info.NumberOfFrames.Value - 1 : int.MaxValue);
 
                 if (frameNumber == FramePosition)
                 {
@@ -62,7 +61,7 @@
                 }
                 else if (frameNumber == FramePosition - 1)
                 {
-                    return new AudioData(stream.RecentlyDecodedFrame);
+                    return new AudioData(stream.RecentlyDecodedFrame as AudioFrame);
                 }
                 else
                 {
@@ -105,7 +104,7 @@
 
         private AudioData GetNextFrameData()
         {
-            var bmp = new AudioData(stream.GetNextFrame());
+            var bmp = new AudioData(stream.GetNextFrame() as AudioFrame);
             FramePosition++;
             return bmp;
         }
@@ -120,7 +119,7 @@
             }
 
             stream.SkipFrames(ts);
-            return stream.RecentlyDecodedFrame;
+            return stream.RecentlyDecodedFrame as AudioFrame;
         }
     }
 }

--- a/FFMediaToolkit/Decoding/AudioStreamInfo.cs
+++ b/FFMediaToolkit/Decoding/AudioStreamInfo.cs
@@ -1,0 +1,57 @@
+﻿namespace FFMediaToolkit.Decoding
+{
+    using System;
+    using FFMediaToolkit.Common;
+    using FFMediaToolkit.Decoding.Internal;
+    using FFMediaToolkit.Helpers;
+    using FFmpeg.AutoGen;
+
+    /// <summary>
+    /// Represents informations about the audio stream.
+    /// </summary>
+    public class AudioStreamInfo : StreamInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioStreamInfo"/> class.
+        /// </summary>
+        /// <param name="stream">A generic stream.</param>
+        /// <param name="container">The input container.</param>
+        internal unsafe AudioStreamInfo(AVStream* stream, InputContainer container)
+             : base(stream, MediaType.Audio, container)
+        {
+            var codec = stream->codec;
+            NumChannels = codec->channels;
+            SampleRate = codec->sample_rate;
+            long num_samples = stream->duration >= 0 ? stream->duration : container.Pointer->duration;
+            AvgNumSamplesPerFrame = (int)Math.Round((double)num_samples / NumberOfFrames.Value);
+            SampleFormat = codec->sample_fmt.FormatEnum(14);
+            AvSampleFormat = codec->sample_fmt;
+        }
+
+        /// <summary>
+        /// Gets the number of audio channels stored in the stream.
+        /// </summary>
+        public int NumChannels { get; }
+
+        /// <summary>
+        /// Gets the number of samples per second of the audio stream.
+        /// </summary>
+        public int SampleRate { get; }
+
+        /// <summary>
+        /// Gets the average number of samples per frame (chunk of samples) calculated from metadata.
+        /// It is used to calculate timestamps in the internal decoder methods.
+        /// </summary>
+        public int AvgNumSamplesPerFrame { get; }
+
+        /// <summary>
+        /// Gets a lowercase string representing the audio sample format.
+        /// </summary>
+        public string SampleFormat { get; }
+
+        /// <summary>
+        /// Gets the audio sample format.
+        /// </summary>
+        internal AVSampleFormat AvSampleFormat { get; }
+    }
+}

--- a/FFMediaToolkit/Decoding/AudioStreamInfo.cs
+++ b/FFMediaToolkit/Decoding/AudioStreamInfo.cs
@@ -1,9 +1,8 @@
 ﻿namespace FFMediaToolkit.Decoding
 {
-    using System;
+    using FFMediaToolkit.Audio;
     using FFMediaToolkit.Common;
     using FFMediaToolkit.Decoding.Internal;
-    using FFMediaToolkit.Helpers;
     using FFmpeg.AutoGen;
 
     /// <summary>
@@ -22,10 +21,9 @@
             var codec = stream->codec;
             NumChannels = codec->channels;
             SampleRate = codec->sample_rate;
-            long num_samples = stream->duration >= 0 ? stream->duration : container.Pointer->duration;
-            AvgNumSamplesPerFrame = (int)Math.Round((double)num_samples / NumberOfFrames.Value);
-            SampleFormat = codec->sample_fmt.FormatEnum(14);
-            AvSampleFormat = codec->sample_fmt;
+            SamplesPerFrame = codec->frame_size > 0 ? codec->frame_size : codec->sample_rate / 20;
+            SampleFormat = (SampleFormat)codec->sample_fmt;
+            ChannelLayout = ffmpeg.av_get_default_channel_layout(codec->channels);
         }
 
         /// <summary>
@@ -42,16 +40,16 @@
         /// Gets the average number of samples per frame (chunk of samples) calculated from metadata.
         /// It is used to calculate timestamps in the internal decoder methods.
         /// </summary>
-        public int AvgNumSamplesPerFrame { get; }
-
-        /// <summary>
-        /// Gets a lowercase string representing the audio sample format.
-        /// </summary>
-        public string SampleFormat { get; }
+        public int SamplesPerFrame { get; }
 
         /// <summary>
         /// Gets the audio sample format.
         /// </summary>
-        internal AVSampleFormat AvSampleFormat { get; }
+        public SampleFormat SampleFormat { get; }
+
+        /// <summary>
+        /// Gets the channel layout for this stream.
+        /// </summary>
+        internal long ChannelLayout { get; }
     }
 }

--- a/FFMediaToolkit/Decoding/Internal/AvioStream.cs
+++ b/FFMediaToolkit/Decoding/Internal/AvioStream.cs
@@ -1,0 +1,70 @@
+﻿namespace FFMediaToolkit.Decoding.Internal
+{
+    using System;
+    using System.IO;
+    using System.Runtime.InteropServices;
+
+    using FFmpeg.AutoGen;
+
+    /// <summary>
+    /// A stream wrapper.
+    /// </summary>
+    internal unsafe class AvioStream
+    {
+        private readonly Stream inputStream;
+
+        private byte[] readBuffer = null;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AvioStream"/> class.
+        /// </summary>
+        /// <param name="input">Multimedia file stream.</param>
+        public AvioStream(Stream input)
+        {
+            inputStream = input ?? throw new ArgumentNullException(nameof(input));
+        }
+
+        /// <summary>
+        /// A method for refilling the buffer. For stream protocols,
+        /// must never return 0 but rather a proper AVERROR code.
+        /// </summary>
+        /// <param name="opaque">An opaque pointer.</param>
+        /// <param name="buffer">A buffer that needs to be filled with stream data.</param>
+        /// <param name="bufferLength">The size of <paramref name="buffer"/>.</param>
+        /// <returns>Number of read bytes.</returns>
+        public int Read(void* opaque, byte* buffer, int bufferLength)
+        {
+            if (readBuffer == null)
+            {
+                readBuffer = new byte[bufferLength];
+            }
+
+            int readed = inputStream.Read(readBuffer, 0, readBuffer.Length);
+            if (readed > 0)
+            {
+                Marshal.Copy(readBuffer, 0, (IntPtr)buffer, readed);
+            }
+
+            return readed;
+        }
+
+        /// <summary>
+        /// A method for seeking to specified byte position.
+        /// </summary>
+        /// <param name="opaque">An opaque pointer.</param>
+        /// <param name="offset">The offset in a stream.</param>
+        /// <param name="whence">The seek option.</param>
+        /// <returns>Position within the current stream or stream size.</returns>
+        public long Seek(void* opaque, long offset, int whence)
+        {
+            if (!inputStream.CanSeek)
+            {
+                return -1;
+            }
+
+            return whence == ffmpeg.AVSEEK_SIZE ?
+                inputStream.Length :
+                inputStream.Seek(offset, SeekOrigin.Begin);
+        }
+    }
+}

--- a/FFMediaToolkit/Decoding/Internal/Decoder.cs
+++ b/FFMediaToolkit/Decoding/Internal/Decoder.cs
@@ -37,12 +37,9 @@
                 default:
                     throw new Exception("Tried to create a decoder from an unsupported stream or codec type.");
             }
-        }
 
-        /// <summary>
-        /// Gets the media container that owns this stream.
-        /// </summary>
-        public InputContainer OwnerFile { get; }
+            BufferedPackets = new Queue<MediaPacket>();
+        }
 
         /// <summary>
         /// Gets informations about the stream.
@@ -50,14 +47,24 @@
         public StreamInfo Info { get; }
 
         /// <summary>
-        /// Gets a FIFO collection of media packets that the codec has buffered.
+        /// Gets the media container that owns this stream.
         /// </summary>
-        public Queue<MediaPacket> BufferedPackets { get; }
+        public InputContainer OwnerFile { get; }
 
         /// <summary>
         /// Gets the recently decoded frame.
         /// </summary>
         public MediaFrame RecentlyDecodedFrame { get; }
+
+        /// <summary>
+        /// Indicates whether the codec has buffered packets.
+        /// </summary>
+        public bool IsBufferEmpty => BufferedPackets.Count == 0;
+
+        /// <summary>
+        /// Gets a FIFO collection of media packets that the codec has buffered.
+        /// </summary>
+        private Queue<MediaPacket> BufferedPackets { get; }
 
         /// <summary>
         /// Adds the specified packet to the codec buffer.
@@ -122,7 +129,7 @@
         {
             if (!reuseLastPacket)
             {
-                if (BufferedPackets.Count == 0)
+                if (IsBufferEmpty)
                     OwnerFile.GetPacketFromStream(Info.Index);
                 packet = BufferedPackets.Dequeue();
             }

--- a/FFMediaToolkit/Decoding/Internal/Decoder.cs
+++ b/FFMediaToolkit/Decoding/Internal/Decoder.cs
@@ -1,8 +1,7 @@
 ﻿namespace FFMediaToolkit.Decoding.Internal
 {
     using System;
-    using System.Collections.Concurrent;
-    using System.IO;
+    using System.Collections.Generic;
     using FFMediaToolkit.Common;
     using FFMediaToolkit.Common.Internal;
     using FFMediaToolkit.Helpers;
@@ -11,13 +10,15 @@
     /// <summary>
     /// Represents a input multimedia stream.
     /// </summary>
-    /// <typeparam name="TFrame">The type of frames in the stream.</typeparam>
-    internal unsafe class Decoder<TFrame> : Wrapper<AVCodecContext>
-        where TFrame : MediaFrame, new()
+    internal unsafe class Decoder : Wrapper<AVCodecContext>
     {
+        private bool reuseLastPacket;
+        private MediaPacket packet;
+
         /// <summary>
-        /// Initializes a new instance of the <see cref="Decoder{TFrame}"/> class.
+        /// Initializes a new instance of the <see cref="Decoder"/> class.
         /// </summary>
+        /// <param name="codec">The underlying codec.</param>
         /// <param name="stream">The multimedia stream.</param>
         /// <param name="owner">The container that owns the stream.</param>
         public Decoder(AVCodecContext* codec, AVStream* stream, InputContainer owner)
@@ -25,6 +26,17 @@
         {
             OwnerFile = owner;
             Info = StreamInfo.Create(stream, owner);
+            switch (Info.Type)
+            {
+                case MediaType.Audio:
+                    RecentlyDecodedFrame = new AudioFrame();
+                    break;
+                case MediaType.Video:
+                    RecentlyDecodedFrame = new VideoFrame();
+                    break;
+                default:
+                    throw new Exception("Tried to create a decoder from an unsupported stream or codec type.");
+            }
         }
 
         /// <summary>
@@ -38,15 +50,29 @@
         public StreamInfo Info { get; }
 
         /// <summary>
+        /// Gets a FIFO collection of media packets that the codec has buffered.
+        /// </summary>
+        public Queue<MediaPacket> BufferedPackets { get; }
+
+        /// <summary>
         /// Gets the recently decoded frame.
         /// </summary>
-        public TFrame RecentlyDecodedFrame { get; private set; } = new TFrame();
+        public MediaFrame RecentlyDecodedFrame { get; }
+
+        /// <summary>
+        /// Adds the specified packet to the codec buffer.
+        /// </summary>
+        /// <param name="packet">The packet to be buffered.</param>
+        public void BufferPacket(MediaPacket packet)
+        {
+            BufferedPackets.Enqueue(packet);
+        }
 
         /// <summary>
         /// Reads the next frame from the stream.
         /// </summary>
         /// <returns>The decoded frame.</returns>
-        public TFrame GetNextFrame()
+        public MediaFrame GetNextFrame()
         {
             ReadNextFrame();
             return RecentlyDecodedFrame;
@@ -94,19 +120,25 @@
 
         private void DecodePacket()
         {
-            var pkt = OwnerFile.ReadNextPacket(Info.Index);
+            if (!reuseLastPacket)
+            {
+                if (BufferedPackets.Count == 0)
+                    OwnerFile.GetPacketFromStream(Info.Index);
+                packet = BufferedPackets.Dequeue();
+            }
 
             // Sends the packet to the decoder.
-            var result = ffmpeg.avcodec_send_packet(Pointer, pkt);
+            var result = ffmpeg.avcodec_send_packet(Pointer, packet);
 
             if (result == ffmpeg.AVERROR(ffmpeg.EAGAIN))
             {
-                OwnerFile.ReuseLastPacket();
+                reuseLastPacket = true;
             }
             else
             {
+                reuseLastPacket = false;
                 result.ThrowIfError("Cannot send a packet to the decoder.");
-                pkt.Wipe();
+                packet.Wipe();
             }
         }
     }

--- a/FFMediaToolkit/Decoding/Internal/Decoder.cs
+++ b/FFMediaToolkit/Decoding/Internal/Decoder.cs
@@ -99,15 +99,29 @@
         }
 
         /// <summary>
+        /// Discards all packet data buffered by this instance.
+        /// </summary>
+        public void DiscardBufferedData()
+        {
+            foreach (var packet in BufferedPackets)
+            {
+                packet.Wipe();
+                packet.Dispose();
+            }
+
+            BufferedPackets.Clear();
+        }
+
+        /// <summary>
         /// Flushes the codec buffers.
         /// </summary>
-        public void FlushBuffers() => ffmpeg.avcodec_flush_buffers(Pointer);
+        public void FlushUnmanagedBuffers() => ffmpeg.avcodec_flush_buffers(Pointer);
 
         /// <inheritdoc/>
         protected override void OnDisposing()
         {
             RecentlyDecodedFrame.Dispose();
-            FlushBuffers();
+            FlushUnmanagedBuffers();
             ffmpeg.avcodec_close(Pointer);
         }
 

--- a/FFMediaToolkit/Decoding/Internal/DecoderFactory.cs
+++ b/FFMediaToolkit/Decoding/Internal/DecoderFactory.cs
@@ -1,8 +1,6 @@
 ﻿namespace FFMediaToolkit.Decoding.Internal
 {
-    using System;
     using FFMediaToolkit.Common;
-    using FFMediaToolkit.Common.Internal;
     using FFMediaToolkit.Helpers;
     using FFmpeg.AutoGen;
 
@@ -16,63 +14,31 @@
         /// </summary>
         /// <param name="container">The media container.</param>
         /// <param name="options">The media options.</param>
-        /// <returns>The opened <see cref="Decoder{TFrame}"/>.</returns>
-        internal static Decoder<VideoFrame> OpenVideo(InputContainer container, MediaOptions options)
+        /// <param name="stream">The stream.</param>
+        /// <returns>The opened <see cref="Decoder"/>.</returns>
+        internal static Decoder OpenStream(InputContainer container, MediaOptions options, AVStream* stream)
         {
             var format = container.Pointer;
             AVCodec* codec = null;
 
-            var index = ffmpeg.av_find_best_stream(format, AVMediaType.AVMEDIA_TYPE_VIDEO, -1, -1, &codec, 0);
-            index.IfError(ffmpeg.AVERROR_DECODER_NOT_FOUND, "Cannot find a codec for the video stream.");
+            var index = ffmpeg.av_find_best_stream(format, stream->codec->codec_type, stream->index, -1, &codec, 0);
+            index.IfError(ffmpeg.AVERROR_DECODER_NOT_FOUND, "Cannot find a codec for the specified stream.");
             if (index < 0)
             {
                 return null;
             }
 
-            var stream = format->streams[index];
             var codecContext = ffmpeg.avcodec_alloc_context3(codec);
             ffmpeg.avcodec_parameters_to_context(codecContext, stream->codecpar)
-                .ThrowIfError("Cannot open the video codec!");
+                .ThrowIfError("Cannot open the stream codec!");
             codecContext->pkt_timebase = stream->time_base;
 
             var dict = new FFDictionary(options.DecoderOptions, false).Pointer;
 
             ffmpeg.avcodec_open2(codecContext, codec, &dict)
-                .ThrowIfError("Cannot open the video codec");
+                .ThrowIfError("Cannot open the stream codec!");
 
-            return new Decoder<VideoFrame>(codecContext, stream, container);
-        }
-
-        /// <summary>
-        /// Opens the audio stream with the specified index in the media container.
-        /// </summary>
-        /// <param name="container">The media container.</param>
-        /// <param name="options">The media options.</param>
-        /// <returns>The opened <see cref="Decoder{TFrame}"/>.</returns>
-        internal static Decoder<AudioFrame> OpenAudio(InputContainer container, MediaOptions options)
-        {
-            var format = container.Pointer;
-            AVCodec* codec = null;
-
-            var index = ffmpeg.av_find_best_stream(format, AVMediaType.AVMEDIA_TYPE_AUDIO, -1, -1, &codec, 0);
-            index.IfError(ffmpeg.AVERROR_DECODER_NOT_FOUND, "Cannot find a codec for the audio stream.");
-            if (index < 0)
-            {
-                return null;
-            }
-
-            var stream = format->streams[index];
-            var codecContext = ffmpeg.avcodec_alloc_context3(codec);
-            ffmpeg.avcodec_parameters_to_context(codecContext, stream->codecpar)
-                .ThrowIfError("Cannot open the audio codec!");
-            codecContext->pkt_timebase = stream->time_base;
-
-            var dict = new FFDictionary(options.DecoderOptions, false).Pointer;
-
-            ffmpeg.avcodec_open2(codecContext, codec, &dict)
-                .ThrowIfError("Cannot open the audio codec");
-
-            return new Decoder<AudioFrame>(codecContext, stream, container);
+            return new Decoder(codecContext, stream, container);
         }
     }
 }

--- a/FFMediaToolkit/Decoding/Internal/InputContainer.cs
+++ b/FFMediaToolkit/Decoding/Internal/InputContainer.cs
@@ -152,9 +152,7 @@
             for (int i = 0; i < Pointer->nb_streams; i++)
             {
                 var stream = Pointer->streams[i];
-                var mode = (MediaMode)(1 << (int)stream->codec->codec_type);
-
-                if (!options.StreamsToLoad.HasFlag(mode))
+                if (!options.ShouldLoadStreamsOfType(stream->codec->codec_type))
                     continue;
 
                 try

--- a/FFMediaToolkit/Decoding/Internal/InputContainer.cs
+++ b/FFMediaToolkit/Decoding/Internal/InputContainer.cs
@@ -89,9 +89,18 @@
             {
                 packet = ReadPacket();
                 var stream = Decoders[packet.StreamIndex];
-                stream.BufferPacket(packet);
+                if (stream == null)
+                {
+                    packet.Wipe();
+                    packet.Dispose();
+                    packet = null;
+                }
+                else
+                {
+                    stream.BufferPacket(packet);
+                }
             }
-            while (packet.StreamIndex != streamIndex);
+            while (packet?.StreamIndex != streamIndex);
         }
 
         /// <inheritdoc/>
@@ -143,6 +152,10 @@
             for (int i = 0; i < Pointer->nb_streams; i++)
             {
                 var stream = Pointer->streams[i];
+                var mode = (MediaMode)(1 << (int)stream->codec->codec_type);
+
+                if (!options.StreamsToLoad.HasFlag(mode))
+                    continue;
 
                 try
                 {

--- a/FFMediaToolkit/Decoding/Internal/InputContainer.cs
+++ b/FFMediaToolkit/Decoding/Internal/InputContainer.cs
@@ -1,5 +1,6 @@
 ﻿namespace FFMediaToolkit.Decoding.Internal
 {
+    using System;
     using System.IO;
 
     using FFMediaToolkit.Common;
@@ -19,6 +20,7 @@
         private InputContainer(AVFormatContext* formatContext)
             : base(formatContext)
         {
+            Decoders = new Decoder[Pointer->nb_streams];
         }
 
         private delegate void AVFormatContextDelegate(AVFormatContext* context);
@@ -142,8 +144,15 @@
             {
                 var stream = Pointer->streams[i];
 
-                DecoderFactory.OpenStream(this, options, stream);
-                GetPacketFromStream(i);
+                try
+                {
+                    Decoders[i] = DecoderFactory.OpenStream(this, options, stream);
+                    GetPacketFromStream(i);
+                }
+                catch (Exception)
+                {
+                    Decoders[i] = null;
+                }
             }
         }
 

--- a/FFMediaToolkit/Decoding/Internal/InputContainer.cs
+++ b/FFMediaToolkit/Decoding/Internal/InputContainer.cs
@@ -74,7 +74,7 @@
         {
             ffmpeg.av_seek_frame(Pointer, streamIndex, targetTs, ffmpeg.AVSEEK_FLAG_BACKWARD).ThrowIfError($"Seek to {targetTs} failed.");
 
-            Decoders[streamIndex].FlushBuffers();
+            Decoders[streamIndex].FlushUnmanagedBuffers();
             GetPacketFromStream(streamIndex);
         }
 

--- a/FFMediaToolkit/Decoding/MediaFile.cs
+++ b/FFMediaToolkit/Decoding/MediaFile.cs
@@ -21,31 +21,41 @@
             var video = container.Decoders.Where(codec => codec?.Info.Type == MediaType.Video);
             var audio = container.Decoders.Where(codec => codec?.Info.Type == MediaType.Audio);
 
-            Video = video.Select(codec => new VideoStream(codec, options)).ToArray();
-            Audio = audio.Select(codec => new AudioStream(codec, options)).ToArray();
+            VideoStreams = video.Select(codec => new VideoStream(codec, options)).ToArray();
+            AudioStreams = audio.Select(codec => new AudioStream(codec, options)).ToArray();
 
             Info = new MediaInfo(container.Pointer);
         }
 
         /// <summary>
-        /// Gets the video streams.
+        /// Gets all the video streams in the media file.
         /// </summary>
-        public VideoStream[] Video { get; }
+        public VideoStream[] VideoStreams { get; }
+
+        /// <summary>
+        /// Gets the first video stream in the media file.
+        /// </summary>
+        public VideoStream Video => VideoStreams.FirstOrDefault();
 
         /// <summary>
         /// Gets a value indicating whether the file contains video streams.
         /// </summary>
-        public bool HasVideo => Video.Length > 0;
+        public bool HasVideo => VideoStreams.Length > 0;
 
         /// <summary>
-        /// Gets the audio streams.
+        /// Gets all the audio streams in the media file.
         /// </summary>
-        public AudioStream[] Audio { get; }
+        public AudioStream[] AudioStreams { get; }
+
+        /// <summary>
+        /// Gets the first audio stream in the media file.
+        /// </summary>
+        public AudioStream Audio => AudioStreams.FirstOrDefault();
 
         /// <summary>
         /// Gets a value indicating whether the file contains video streams.
         /// </summary>
-        public bool HasAudio => Audio.Length > 0;
+        public bool HasAudio => AudioStreams.Length > 0;
 
         /// <summary>
         /// Gets informations about the media container.
@@ -116,8 +126,8 @@
                 return;
             }
 
-            var video = Video.Cast<MediaStream>();
-            var audio = Audio.Cast<MediaStream>();
+            var video = VideoStreams.Cast<MediaStream>();
+            var audio = AudioStreams.Cast<MediaStream>();
 
             var streams = video.Concat(audio);
 

--- a/FFMediaToolkit/Decoding/MediaFile.cs
+++ b/FFMediaToolkit/Decoding/MediaFile.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.IO;
+
     using FFMediaToolkit.Decoding.Internal;
 
     /// <summary>
@@ -81,6 +82,32 @@
             catch (Exception ex)
             {
                 throw new Exception("Failed to open the media file", ex);
+            }
+        }
+
+        /// <summary>
+        /// Opens a media stream with default settings.
+        /// </summary>
+        /// <param name="stream">A stream of the multimedia file.</param>
+        /// <returns>The opened <see cref="MediaFile"/>.</returns>
+        public static MediaFile Open(Stream stream) => Open(stream, new MediaOptions());
+
+        /// <summary>
+        /// Opens a media stream.
+        /// </summary>
+        /// <param name="stream">A stream of the multimedia file.</param>
+        /// <param name="options">The decoder settings.</param>
+        /// <returns>The opened <see cref="MediaFile"/>.</returns>
+        public static MediaFile Open(Stream stream, MediaOptions options)
+        {
+            try
+            {
+                var container = InputContainer.LoadStream(stream, options);
+                return new MediaFile(container, options);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Failed to open the media stream", ex);
             }
         }
 

--- a/FFMediaToolkit/Decoding/MediaFile.cs
+++ b/FFMediaToolkit/Decoding/MediaFile.cs
@@ -2,7 +2,8 @@
 {
     using System;
     using System.IO;
-
+    using System.Linq;
+    using FFMediaToolkit.Common;
     using FFMediaToolkit.Decoding.Internal;
 
     /// <summary>
@@ -17,14 +18,17 @@
         {
             this.container = container;
 
-            if (container.Video != null)
+            var video = container.Decoders.FirstOrDefault(codec => codec.Info.Type == MediaType.Video);
+            var audio = container.Decoders.FirstOrDefault(codec => codec.Info.Type == MediaType.Audio);
+
+            if (video != null)
             {
-                Video = new VideoStream(container.Video, options);
+                Video = new VideoStream(video, options);
             }
 
-            if (container.Audio != null)
+            if (audio != null)
             {
-                Audio = new AudioStream(container.Audio, options);
+                Audio = new AudioStream(audio, options);
             }
 
             Info = new MediaInfo(container.Pointer);

--- a/FFMediaToolkit/Decoding/MediaFile.cs
+++ b/FFMediaToolkit/Decoding/MediaFile.cs
@@ -18,8 +18,8 @@
         {
             this.container = container;
 
-            var video = container.Decoders.Where(codec => codec.Info.Type == MediaType.Video);
-            var audio = container.Decoders.Where(codec => codec.Info.Type == MediaType.Audio);
+            var video = container.Decoders.Where(codec => codec?.Info.Type == MediaType.Video);
+            var audio = container.Decoders.Where(codec => codec?.Info.Type == MediaType.Audio);
 
             if (video.Any())
             {
@@ -40,9 +40,19 @@
         public VideoStream[] Video { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the file contains video streams.
+        /// </summary>
+        public bool HasVideo => Video.Length > 0;
+
+        /// <summary>
         /// Gets the audio streams.
         /// </summary>
         public AudioStream[] Audio { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the file contains video streams.
+        /// </summary>
+        public bool HasAudio => Audio.Length > 0;
 
         /// <summary>
         /// Gets informations about the media container.

--- a/FFMediaToolkit/Decoding/MediaFile.cs
+++ b/FFMediaToolkit/Decoding/MediaFile.cs
@@ -21,15 +21,8 @@
             var video = container.Decoders.Where(codec => codec?.Info.Type == MediaType.Video);
             var audio = container.Decoders.Where(codec => codec?.Info.Type == MediaType.Audio);
 
-            if (video.Any())
-            {
-                Video = video.Select(codec => new VideoStream(codec, options)).ToArray();
-            }
-
-            if (audio.Any())
-            {
-                Audio = audio.Select(codec => new AudioStream(codec, options)).ToArray();
-            }
+            Video = video.Select(codec => new VideoStream(codec, options)).ToArray();
+            Audio = audio.Select(codec => new AudioStream(codec, options)).ToArray();
 
             Info = new MediaInfo(container.Pointer);
         }

--- a/FFMediaToolkit/Decoding/MediaOptions.cs
+++ b/FFMediaToolkit/Decoding/MediaOptions.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Drawing;
     using FFMediaToolkit.Graphics;
+    using FFmpeg.AutoGen;
 
     /// <summary>
     /// Represents the audio/video streams loading modes.
@@ -14,12 +15,12 @@
         /// <summary>
         /// Enables loading only video streams.
         /// </summary>
-        Video = 1,
+        Video = 1 << AVMediaType.AVMEDIA_TYPE_VIDEO,
 
         /// <summary>
         /// Enables loading only audio streams.
         /// </summary>
-        Audio = 2,
+        Audio = 1 << AVMediaType.AVMEDIA_TYPE_AUDIO,
 
         /// <summary>
         /// Enables loading both audio and video streams if they exist.
@@ -83,5 +84,17 @@
         /// Gets or sets which streams (audio/video) will be loaded.
         /// </summary>
         public MediaMode StreamsToLoad { get; set; } = MediaMode.AudioVideo;
+
+        /// <summary>
+        /// Determines whether streams of a certain <see cref="AVMediaType"/> should be loaded
+        /// (Based on <see cref="StreamsToLoad"/> property).
+        /// </summary>
+        /// <param name="type">A given <see cref="AVMediaType"/>.</param>
+        /// <returns><see langword="true"/> if streams of the <see cref="AVMediaType"/> given are to be loaded.</returns>
+        public bool ShouldLoadStreamsOfType(AVMediaType type)
+        {
+            var mode = (MediaMode)(1 << (int)type);
+            return StreamsToLoad.HasFlag(mode);
+        }
     }
 }

--- a/FFMediaToolkit/Decoding/MediaOptions.cs
+++ b/FFMediaToolkit/Decoding/MediaOptions.cs
@@ -2,29 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Drawing;
-    using FFMediaToolkit.Common;
     using FFMediaToolkit.Graphics;
-
-    /// <summary>
-    /// Represents the audio/video streams loading modes.
-    /// </summary>
-    internal enum MediaMode
-    {
-        /// <summary>
-        /// Enables loading both audio and video streams if exists.
-        /// </summary>
-        AudioVideo,
-
-        /// <summary>
-        /// Enables loading only video stream.
-        /// </summary>
-        Video,
-
-        /// <summary>
-        /// Enables loading only audio stream.
-        /// </summary>
-        Audio,
-    }
 
     /// <summary>
     /// Represents the multimedia file container options.
@@ -77,10 +55,5 @@
         /// Gets or sets the dictionary with global options for the multimedia decoders.
         /// </summary>
         public Dictionary<string, string> DecoderOptions { get; set; } = new Dictionary<string, string>();
-
-        /// <summary>
-        /// Gets or sets which streams (audio/video) will be loaded.
-        /// </summary>
-        internal MediaMode StreamsToLoad { get; set; } = MediaMode.AudioVideo;
     }
 }

--- a/FFMediaToolkit/Decoding/MediaOptions.cs
+++ b/FFMediaToolkit/Decoding/MediaOptions.cs
@@ -1,8 +1,31 @@
 ﻿namespace FFMediaToolkit.Decoding
 {
+    using System;
     using System.Collections.Generic;
     using System.Drawing;
     using FFMediaToolkit.Graphics;
+
+    /// <summary>
+    /// Represents the audio/video streams loading modes.
+    /// </summary>
+    [Flags]
+    public enum MediaMode
+    {
+        /// <summary>
+        /// Enables loading only video streams.
+        /// </summary>
+        Video = 1,
+
+        /// <summary>
+        /// Enables loading only audio streams.
+        /// </summary>
+        Audio = 2,
+
+        /// <summary>
+        /// Enables loading both audio and video streams if they exist.
+        /// </summary>
+        AudioVideo = Audio | Video,
+    }
 
     /// <summary>
     /// Represents the multimedia file container options.
@@ -55,5 +78,10 @@
         /// Gets or sets the dictionary with global options for the multimedia decoders.
         /// </summary>
         public Dictionary<string, string> DecoderOptions { get; set; } = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Gets or sets which streams (audio/video) will be loaded.
+        /// </summary>
+        public MediaMode StreamsToLoad { get; set; } = MediaMode.AudioVideo;
     }
 }

--- a/FFMediaToolkit/Decoding/MediaStream.cs
+++ b/FFMediaToolkit/Decoding/MediaStream.cs
@@ -31,7 +31,7 @@
         /// <summary>
         /// Gets the timestamp of the recently decoded frame in the media stream.
         /// </summary>
-        public TimeSpan Position => Stream.RecentlyDecodedFrame.PresentationTimestamp.ToTimeSpan(Info.TimeBase);
+        public TimeSpan Position => Math.Max(Stream.RecentlyDecodedFrame.PresentationTimestamp, 0).ToTimeSpan(Info.TimeBase);
 
         /// <summary>
         /// Indicates whether the stream has buffered frame data.

--- a/FFMediaToolkit/Decoding/MediaStream.cs
+++ b/FFMediaToolkit/Decoding/MediaStream.cs
@@ -1,0 +1,99 @@
+﻿namespace FFMediaToolkit.Decoding
+{
+    using System;
+    using FFMediaToolkit.Common.Internal;
+    using FFMediaToolkit.Decoding.Internal;
+    using FFMediaToolkit.Helpers;
+
+    /// <summary>
+    /// A base for streams of any kind of media.
+    /// </summary>
+    public class MediaStream : IDisposable
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MediaStream"/> class.
+        /// </summary>
+        /// <param name="stream">The associated codec.</param>
+        /// <param name="options">Extra options.</param>
+        internal MediaStream(Decoder stream, MediaOptions options)
+        {
+            Stream = stream;
+            Options = options;
+
+            Threshold = TimeSpan.FromSeconds(0.5).ToTimestamp(Info.TimeBase);
+        }
+
+        /// <summary>
+        /// Gets informations about this stream.
+        /// </summary>
+        public StreamInfo Info => Stream.Info;
+
+        /// <summary>
+        /// Gets the timestamp of the recently decoded frame in the video stream.
+        /// </summary>
+        public TimeSpan Position => Stream.RecentlyDecodedFrame.PresentationTimestamp.ToTimeSpan(Info.TimeBase);
+
+        /// <summary>
+        /// Indicates whether the stream has buffered frame data.
+        /// </summary>
+        public bool IsBufferEmpty => Stream.IsBufferEmpty;
+
+        /// <summary>
+        /// Gets the options configured for this <see cref="MediaStream"/>.
+        /// </summary>
+        protected MediaOptions Options { get; }
+
+        private Decoder Stream { get; }
+
+        private long Threshold { get; }
+
+        /// <inheritdoc/>
+        public virtual void Dispose()
+        {
+            Stream.Dispose();
+        }
+
+        /// <summary>
+        /// Gets the data belonging to the next frame in the stream.
+        /// </summary>
+        /// <returns>The next frame's data.</returns>
+        internal MediaFrame GetNextFrame()
+        {
+            return Stream.GetNextFrame();
+        }
+
+        /// <summary>
+        /// Seeks the stream to the specified time and returns the nearest frame's data.
+        /// </summary>
+        /// <param name="time">A specific point in time in this stream.</param>
+        /// <returns>The nearest frame's data.</returns>
+        internal MediaFrame GetFrame(TimeSpan time)
+        {
+            var ts = time.ToTimestamp(Info.TimeBase);
+            var frame = GetFrameByTimestamp(ts);
+            return frame;
+        }
+
+        private MediaFrame GetFrameByTimestamp(long ts)
+        {
+            var frame = Stream.RecentlyDecodedFrame;
+            ts = Math.Max(0, Math.Min(ts, Info.DurationRaw));
+
+            if (ts > frame.PresentationTimestamp && ts < frame.PresentationTimestamp + Threshold)
+            {
+                return Stream.GetNextFrame();
+            }
+            else if (ts != frame.PresentationTimestamp)
+            {
+                if (ts < frame.PresentationTimestamp || ts >= frame.PresentationTimestamp + Threshold)
+                {
+                    Stream.OwnerFile.SeekFile(ts, Info.Index);
+                }
+
+                Stream.SkipFrames(ts);
+            }
+
+            return Stream.RecentlyDecodedFrame;
+        }
+    }
+}

--- a/FFMediaToolkit/Decoding/MediaStream.cs
+++ b/FFMediaToolkit/Decoding/MediaStream.cs
@@ -47,9 +47,15 @@
 
         private long Threshold { get; }
 
+        /// <summary>
+        /// Discards all buffered frame data associated with this stream.
+        /// </summary>
+        public void DiscardBufferedData() => Stream.DiscardBufferedData();
+
         /// <inheritdoc/>
-        public virtual void Dispose()
+        public void Dispose()
         {
+            DiscardBufferedData();
             Stream.Dispose();
         }
 
@@ -57,10 +63,7 @@
         /// Gets the data belonging to the next frame in the stream.
         /// </summary>
         /// <returns>The next frame's data.</returns>
-        internal MediaFrame GetNextFrame()
-        {
-            return Stream.GetNextFrame();
-        }
+        internal MediaFrame GetNextFrame() => Stream.GetNextFrame();
 
         /// <summary>
         /// Seeks the stream to the specified time and returns the nearest frame's data.

--- a/FFMediaToolkit/Decoding/MediaStream.cs
+++ b/FFMediaToolkit/Decoding/MediaStream.cs
@@ -29,7 +29,7 @@
         public StreamInfo Info => Stream.Info;
 
         /// <summary>
-        /// Gets the timestamp of the recently decoded frame in the video stream.
+        /// Gets the timestamp of the recently decoded frame in the media stream.
         /// </summary>
         public TimeSpan Position => Stream.RecentlyDecodedFrame.PresentationTimestamp.ToTimeSpan(Info.TimeBase);
 
@@ -53,7 +53,7 @@
         public void DiscardBufferedData() => Stream.DiscardBufferedData();
 
         /// <inheritdoc/>
-        public void Dispose()
+        public virtual void Dispose()
         {
             DiscardBufferedData();
             Stream.Dispose();

--- a/FFMediaToolkit/Decoding/StreamInfo.cs
+++ b/FFMediaToolkit/Decoding/StreamInfo.cs
@@ -44,8 +44,10 @@
                 DurationRaw = Duration.ToTimestamp(TimeBase);
             }
 
-            var start = stream->start_time.ToTimeSpan(stream->time_base);
-            StartTime = start == TimeSpan.MinValue ? TimeSpan.Zero : start;
+            if (stream->start_time >= 0)
+            {
+                StartTime = stream->start_time.ToTimeSpan(stream->time_base);
+            }
 
             if (stream->nb_frames > 0)
             {

--- a/FFMediaToolkit/Decoding/StreamInfo.cs
+++ b/FFMediaToolkit/Decoding/StreamInfo.cs
@@ -26,6 +26,8 @@
             CodecName = ffmpeg.avcodec_get_name(codec->codec_id);
             CodecId = codec->codec_id.FormatEnum(12);
             Index = stream->index;
+            Type = type;
+
             TimeBase = stream->time_base;
             RealFrameRate = stream->r_frame_rate;
             AvgFrameRate = stream->avg_frame_rate.ToDouble();

--- a/FFMediaToolkit/Decoding/VideoStream.cs
+++ b/FFMediaToolkit/Decoding/VideoStream.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Drawing;
+    using System.IO;
     using FFMediaToolkit.Common.Internal;
     using FFMediaToolkit.Decoding.Internal;
     using FFMediaToolkit.Graphics;
@@ -14,10 +15,10 @@
     public class VideoStream : IDisposable
     {
         private readonly Decoder<VideoFrame> stream;
-        private readonly VideoFrame frame;
         private readonly Lazy<ImageConverter> converter;
         private readonly MediaOptions mediaOptions;
         private readonly Size outputFrameSize;
+        private readonly long threshold;
 
         private readonly object syncLock = new object();
 
@@ -30,9 +31,10 @@
         {
             stream = video;
             mediaOptions = options;
-            frame = VideoFrame.CreateEmpty();
-            outputFrameSize = options.TargetVideoSize ?? Info.FrameSize;
-            converter = new Lazy<ImageConverter>(() => new ImageConverter(Info.FrameSize, Info.AVPixelFormat, outputFrameSize, (AVPixelFormat)options.VideoPixelFormat));
+
+            outputFrameSize = options.TargetVideoSize ?? video.Info.FrameSize;
+            converter = new Lazy<ImageConverter>(() => new ImageConverter(video.Info.FrameSize, video.Info.AVPixelFormat, outputFrameSize, (AVPixelFormat)options.VideoPixelFormat));
+            threshold = TimeSpan.FromSeconds(0.5).ToTimestamp(Info.TimeBase);
         }
 
         /// <summary>
@@ -46,9 +48,9 @@
         public int FramePosition { get; private set; }
 
         /// <summary>
-        /// Gets the timestamp of the next frame in the video stream.
+        /// Gets the timestamp of the recently decoded frame in the video stream.
         /// </summary>
-        public TimeSpan Position => FramePosition.ToTimeSpan(Info.AvgFrameRate);
+        public TimeSpan Position => stream.RecentlyDecodedFrame.PresentationTimestamp.ToTimeSpan(Info.TimeBase);
 
         /// <summary>
         /// Reads the specified video frame.
@@ -60,23 +62,76 @@
         {
             lock (syncLock)
             {
-                frameNumber = frameNumber.Clamp(0, Info.FrameCount != 0 ? Info.FrameCount - 1 : int.MaxValue);
+                var frame = GetFrame(frameNumber, Info.FrameCount);
+                return frame.ToBitmap(converter.Value, mediaOptions.VideoPixelFormat, outputFrameSize);
+            }
+        }
 
-                if (frameNumber == FramePosition)
-                {
-                    return GetNextFrameAsBitmap();
-                }
-                else if (frameNumber == FramePosition - 1)
-                {
-                    return ConvertVideoFrameToBitmap(stream.RecentlyDecodedFrame);
-                }
-                else
-                {
-                    var frame = SeekToFrame(frameNumber);
-                    FramePosition = frameNumber + 1;
+        /// <summary>
+        /// Reads the specified video frame.
+        /// This does not work with Variable Frame Rate videos! Use the <see cref="ReadFrame(TimeSpan)"/> overload instead.
+        /// A <see langword="false"/> return value indicates that reached end of stream so frame was not read. 
+        /// The method throws exception if another error has occurred.
+        /// </summary>
+        /// <param name="frameNumber">The frame index (zero-based number).</param>
+        /// <param name="bitmap">The decoded video frame.</param>
+        /// <returns><see langword="false"/> if reached end of the stream.</returns>
+        public bool TryReadFrame(int frameNumber, out ImageData bitmap)
+        {
+            if (Info.IsVariableFrameRate)
+            {
+                throw new NotSupportedException("Access to frame by index is not supported in variable frame rate video.");
+            }
 
-                    return ConvertVideoFrameToBitmap(frame);
+            lock (syncLock)
+            {
+                VideoFrame frame;
+                try
+                {
+                    frame = GetFrame(frameNumber, Info.NumberOfFrames.Value);
                 }
+                catch (EndOfStreamException)
+                {
+                    bitmap = default;
+                    return false;
+                }
+
+                bitmap = frame.ToBitmap(converter.Value, mediaOptions.VideoPixelFormat, outputFrameSize);
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Reads the specified video frame and writes the converted bitmap bytes directly to the provided buffer. A <see cref="false"/> return value indicates that reached end of stream so frame was not read. The method throws exception if another error has occurred.
+        /// This does not work with Variable Frame Rate videos! Use the <see cref="ReadFrame(TimeSpan)"/> overload instead.
+        /// A <see langword="false"/> return value indicates that reached end of stream.
+        /// The method throws exception if another error has occurred.
+        /// </summary>
+        /// <param name="frameNumber">The frame index (zero-based number).</param>
+        /// <param name="buffer">Pointer to the memory buffer.</param>
+        /// <param name="bufferStride">Number of bytes in a single row of pixel data.</param>
+        /// <returns><see langword="false"/> if reached end of the stream.</returns>
+        public bool TryReadFrameToPointer(int frameNumber, IntPtr buffer, int bufferStride)
+        {
+            if (Info.IsVariableFrameRate)
+            {
+                throw new NotSupportedException("Access to frame by index is not supported in variable frame rate video.");
+            }
+
+            lock (syncLock)
+            {
+                VideoFrame frame;
+                try
+                {
+                    frame = GetFrame(frameNumber, Info.NumberOfFrames.Value);
+                }
+                catch (EndOfStreamException)
+                {
+                    return false;
+                }
+
+                CopyFrameToMemory(frame, buffer, bufferStride);
+                return true;
             }
         }
 
@@ -85,17 +140,135 @@
         /// </summary>
         /// <param name="targetTime">The frame timestamp.</param>
         /// <returns>The decoded video frame.</returns>
-        public ImageData ReadFrame(TimeSpan targetTime) => ReadFrame(targetTime.ToFrameNumber(Info.RealFrameRate));
+        public ImageData ReadFrame(TimeSpan targetTime)
+        {
+            lock (syncLock)
+            {
+                var frame = GetFrameByTimestamp(targetTime.ToTimestamp(Info.TimeBase));
+                return frame.ToBitmap(converter.Value, mediaOptions.VideoPixelFormat, outputFrameSize);
+            }
+        }
+
+        /// <summary>
+        /// Reads the video frame found at the specified timestamp.
+        /// A <see langword="false"/> return value indicates that reached end of stream.
+        /// The method throws exception if another error has occurred.
+        /// </summary>
+        /// <param name="targetTime">The frame timestamp.</param>
+        /// <param name="bitmap">The decoded video frame.</param>
+        /// <returns><see langword="false"/> if reached end of the stream.</returns>
+        public bool TryReadFrame(TimeSpan targetTime, out ImageData bitmap)
+        {
+            lock (syncLock)
+            {
+                VideoFrame frame;
+                try
+                {
+                    frame = GetFrameByTimestamp(targetTime.ToTimestamp(Info.TimeBase));
+                }
+                catch (EndOfStreamException)
+                {
+                    bitmap = default;
+                    return false;
+                }
+
+                bitmap = frame.ToBitmap(converter.Value, mediaOptions.VideoPixelFormat, outputFrameSize);
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Reads the video frame found at the specified timestamp.
+        /// A <see langword="false"/> return value indicates that reached end of stream.
+        /// The method throws exception if another error has occurred.
+        /// </summary>
+        /// <param name="targetTime">The frame timestamp.</param>
+        /// <param name="buffer">Pointer to the memory buffer.</param>
+        /// <param name="bufferStride">Number of bytes in a single row of pixel data.</param>
+        /// <returns><see langword="false"/> if reached end of the stream.</returns>
+        public bool TryReadFrameToPointer(TimeSpan targetTime, IntPtr buffer, int bufferStride)
+        {
+            lock (syncLock)
+            {
+                VideoFrame frame;
+                try
+                {
+                    frame = GetFrameByTimestamp(targetTime.ToTimestamp(Info.TimeBase));
+                }
+                catch (EndOfStreamException)
+                {
+                    return false;
+                }
+
+                CopyFrameToMemory(frame, buffer, bufferStride);
+                return true;
+            }
+        }
 
         /// <summary>
         /// Reads the next frame from this stream.
         /// </summary>
         /// <returns>The decoded video frame.</returns>
-        public unsafe ImageData ReadNextFrame()
+        public ImageData ReadNextFrame()
         {
             lock (syncLock)
             {
-                return GetNextFrameAsBitmap();
+                var frame = GetNextFrame();
+                return frame.ToBitmap(converter.Value, mediaOptions.VideoPixelFormat, outputFrameSize);
+            }
+        }
+
+        /// <summary>
+        /// Reads the next frame from this stream.
+        /// A <see langword="false"/> return value indicates that reached end of stream.
+        /// The method throws exception if another error has occurred.
+        /// </summary>
+        /// <param name="bitmap">The decoded video frame.</param>
+        /// <returns><see langword="false"/> if reached end of the stream.</returns>
+        public bool TryReadNextFrame(out ImageData bitmap)
+        {
+            lock (syncLock)
+            {
+                VideoFrame frame;
+                try
+                {
+                    frame = GetNextFrame();
+                }
+                catch (EndOfStreamException)
+                {
+                    bitmap = default;
+                    return false;
+                }
+
+                bitmap = frame.ToBitmap(converter.Value, mediaOptions.VideoPixelFormat, outputFrameSize);
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Reads the next frame from this stream and writes the converted bitmap bytes directly to the provided buffer.
+        /// A <see langword="false"/> return value indicates that reached end of stream.
+        /// The method throws exception if another error has occurred.
+        /// </summary>
+        /// <param name="buffer">Pointer to the memory buffer.</param>
+        /// <param name="bufferStride">Number of bytes in a single row of pixel data.</param>
+        /// <returns><see langword="false"/> if reached end of the stream.</returns>
+        public bool TryReadNextFrameToPointer(IntPtr buffer, int bufferStride)
+        {
+            lock (syncLock)
+            {
+                VideoFrame frame;
+                try
+                {
+                    frame = GetNextFrame();
+                }
+                catch (EndOfStreamException)
+                {
+                    return false;
+                }
+
+                CopyFrameToMemory(frame, buffer, bufferStride);
+                return true;
             }
         }
 
@@ -105,7 +278,6 @@
             lock (syncLock)
             {
                 stream.Dispose();
-                frame.Dispose();
 
                 if (converter.IsValueCreated)
                 {
@@ -114,32 +286,69 @@
             }
         }
 
-        private ImageData GetNextFrameAsBitmap()
+        private VideoFrame GetFrame(int frameNumber, int frameCount)
         {
-            var bmp = ConvertVideoFrameToBitmap(stream.GetNextFrame());
-            FramePosition++;
-            return bmp;
-        }
+            frameNumber = frameNumber.Clamp(0, frameCount != 0 ? frameCount - 1 : int.MaxValue);
 
-        private unsafe ImageData ConvertVideoFrameToBitmap(VideoFrame frame)
-        {
-            // Gets the target size of the frame (it may be set by the MediaOptions.TargetVideoSize).
-            var bitmap = ImageData.CreatePooled(outputFrameSize, mediaOptions.VideoPixelFormat); // Rents memory for the output bitmap.
-            converter.Value.AVFrameToBitmap(frame, bitmap); // Converts the raw video frame using the given size and pixel format and writes it to the ImageData bitmap.
-            return bitmap;
-        }
-
-        private VideoFrame SeekToFrame(int frameNumber)
-        {
-            var ts = frameNumber.ToTimestamp(Info.RealFrameRate, Info.TimeBase);
-
-            if (frameNumber < FramePosition || frameNumber > FramePosition + mediaOptions.VideoSeekThreshold)
+            if (frameNumber == FramePosition)
             {
-                stream.OwnerFile.SeekFile(ts, Info.Index);
+                return GetNextFrame();
+            }
+            else if (frameNumber != FramePosition - 1)
+            {
+                var ts = frameNumber.ToTimestamp(Info.RealFrameRate, Info.TimeBase);
+
+                if (frameNumber < FramePosition || frameNumber > FramePosition + mediaOptions.VideoSeekThreshold)
+                {
+                    stream.OwnerFile.SeekFile(ts, Info.Index);
+                }
+
+                stream.SkipFrames(frameNumber.ToTimestamp(Info.RealFrameRate, Info.TimeBase));
+                FramePosition = frameNumber + 1;
             }
 
-            stream.SkipFrames(frameNumber.ToTimestamp(Info.RealFrameRate, Info.TimeBase));
             return stream.RecentlyDecodedFrame;
+        }
+
+        private VideoFrame GetFrameByTimestamp(long ts)
+        {
+            var frame = stream.RecentlyDecodedFrame;
+            ts = Math.Max(0, Math.Min(ts, Info.DurationRaw));
+
+            if (ts > frame.PresentationTimestamp && ts < frame.PresentationTimestamp + threshold)
+            {
+                return GetNextFrame();
+            }
+            else if (ts != frame.PresentationTimestamp)
+            {
+                if (ts < frame.PresentationTimestamp || ts >= frame.PresentationTimestamp + threshold)
+                {
+                    stream.OwnerFile.SeekFile(ts, Info.Index);
+                }
+
+                stream.SkipFrames(ts);
+                FramePosition = Position.ToFrameNumber(Info.RealFrameRate) + 1;
+            }
+
+            return stream.RecentlyDecodedFrame;
+        }
+
+        private VideoFrame GetNextFrame()
+        {
+            var frame = stream.GetNextFrame();
+            FramePosition++;
+            return frame;
+        }
+
+        private unsafe void CopyFrameToMemory(VideoFrame frame, IntPtr target, int stride)
+        {
+            if (stride != ImageData.EstimateStride(outputFrameSize.Width, mediaOptions.VideoPixelFormat))
+            {
+                throw new ArgumentOutOfRangeException(nameof(stride), "Stride does not match output bitmap size and pixel format.");
+            }
+
+            var ptr = (byte*)target.ToPointer();
+            converter.Value.AVFrameToBitmap(frame, ptr, stride);
         }
     }
 }

--- a/FFMediaToolkit/Decoding/VideoStream.cs
+++ b/FFMediaToolkit/Decoding/VideoStream.cs
@@ -12,141 +12,69 @@
     /// <summary>
     /// Represents a video stream in the <see cref="MediaFile"/>.
     /// </summary>
-    public class VideoStream : IDisposable
+    public class VideoStream : MediaStream
     {
-        private readonly Decoder stream;
-        private readonly Lazy<ImageConverter> converter;
-        private readonly MediaOptions mediaOptions;
-        private readonly Size outputFrameSize;
-        private readonly long threshold;
-
-        private readonly object syncLock = new object();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="VideoStream"/> class.
         /// </summary>
-        /// <param name="video">The video stream.</param>
+        /// <param name="stream">The video stream.</param>
         /// <param name="options">The decoder settings.</param>
-        internal VideoStream(Decoder video, MediaOptions options)
+        internal VideoStream(Decoder stream, MediaOptions options)
+            : base(stream, options)
         {
-            stream = video;
-            mediaOptions = options;
-
-            outputFrameSize = options.TargetVideoSize ?? Info.FrameSize;
-            converter = new Lazy<ImageConverter>(() => new ImageConverter(Info.FrameSize, Info.AVPixelFormat, outputFrameSize, (AVPixelFormat)options.VideoPixelFormat));
-            threshold = TimeSpan.FromSeconds(0.5).ToTimestamp(Info.TimeBase);
+            OutputFrameSize = options.TargetVideoSize ?? Info.FrameSize;
+            Converter = new Lazy<ImageConverter>(() => new ImageConverter(Info.FrameSize, Info.AVPixelFormat, OutputFrameSize, (AVPixelFormat)options.VideoPixelFormat));
         }
 
         /// <summary>
         /// Gets informations about this stream.
         /// </summary>
-        public VideoStreamInfo Info => (VideoStreamInfo)stream.Info;
+        public new VideoStreamInfo Info => base.Info as VideoStreamInfo;
+
+        private Lazy<ImageConverter> Converter { get; }
+
+        private Size OutputFrameSize { get; }
 
         /// <summary>
-        /// Gets the index of the next frame in the video stream.
+        /// Reads the next frame from the video stream.
         /// </summary>
-        public int FramePosition { get; private set; }
-
-        /// <summary>
-        /// Gets the timestamp of the recently decoded frame in the video stream.
-        /// </summary>
-        public TimeSpan Position => stream.RecentlyDecodedFrame.PresentationTimestamp.ToTimeSpan(Info.TimeBase);
-
-        /// <summary>
-        /// Reads the specified video frame.
-        /// This does not work with Variable Frame Rate videos! Use the <see cref="ReadFrame(TimeSpan)"/> overload instead.
-        /// </summary>
-        /// <param name="frameNumber">The frame index (zero-based number).</param>
-        /// <returns>The decoded video frame.</returns>
-        public ImageData ReadFrame(int frameNumber)
+        /// <returns>A decoded bitmap.</returns>
+        public new ImageData GetNextFrame()
         {
-            lock (syncLock)
-            {
-                var frame = GetFrame(frameNumber, Info.NumberOfFrames.Value);
-                return frame.ToBitmap(converter.Value, mediaOptions.VideoPixelFormat, outputFrameSize);
-            }
+            var frame = base.GetNextFrame() as VideoFrame;
+            return frame.ToBitmap(Converter.Value, Options.VideoPixelFormat, OutputFrameSize);
         }
 
         /// <summary>
-        /// Reads the specified video frame.
-        /// This does not work with Variable Frame Rate videos! Use the <see cref="ReadFrame(TimeSpan)"/> overload instead.
-        /// A <see langword="false"/> return value indicates that reached end of stream so frame was not read.
-        /// The method throws exception if another error has occurred.
-        /// </summary>
-        /// <param name="frameNumber">The frame index (zero-based number).</param>
-        /// <param name="bitmap">The decoded video frame.</param>
-        /// <returns><see langword="false"/> if reached end of the stream.</returns>
-        public bool TryReadFrame(int frameNumber, out ImageData bitmap)
-        {
-            if (Info.IsVariableFrameRate)
-            {
-                throw new NotSupportedException("Access to frame by index is not supported in variable frame rate video.");
-            }
-
-            lock (syncLock)
-            {
-                VideoFrame frame;
-                try
-                {
-                    frame = GetFrame(frameNumber, Info.NumberOfFrames.Value);
-                }
-                catch (EndOfStreamException)
-                {
-                    bitmap = default;
-                    return false;
-                }
-
-                bitmap = frame.ToBitmap(converter.Value, mediaOptions.VideoPixelFormat, outputFrameSize);
-                return true;
-            }
-        }
-
-        /// <summary>
-        /// Reads the specified video frame and writes the converted bitmap bytes directly to the provided buffer. A <see langword="false"/> return value indicates that reached end of stream so frame was not read. The method throws exception if another error has occurred.
-        /// This does not work with Variable Frame Rate videos! Use the <see cref="ReadFrame(TimeSpan)"/> overload instead.
+        /// Reads the next frame from the video stream.
         /// A <see langword="false"/> return value indicates that reached end of stream.
         /// The method throws exception if another error has occurred.
         /// </summary>
-        /// <param name="frameNumber">The frame index (zero-based number).</param>
-        /// <param name="buffer">Pointer to the memory buffer.</param>
-        /// <param name="bufferStride">Number of bytes in a single row of pixel data.</param>
+        /// <param name="bitmap">The decoded video frame.</param>
         /// <returns><see langword="false"/> if reached end of the stream.</returns>
-        public bool TryReadFrameToPointer(int frameNumber, IntPtr buffer, int bufferStride)
+        public bool TryGetNextFrame(out ImageData bitmap)
         {
-            if (Info.IsVariableFrameRate)
+            try
             {
-                throw new NotSupportedException("Access to frame by index is not supported in variable frame rate video.");
-            }
-
-            lock (syncLock)
-            {
-                VideoFrame frame;
-                try
-                {
-                    frame = GetFrame(frameNumber, Info.NumberOfFrames.Value);
-                }
-                catch (EndOfStreamException)
-                {
-                    return false;
-                }
-
-                CopyFrameToMemory(frame, buffer, bufferStride);
+                bitmap = GetNextFrame();
                 return true;
+            }
+            catch (EndOfStreamException)
+            {
+                bitmap = default;
+                return false;
             }
         }
 
         /// <summary>
         /// Reads the video frame found at the specified timestamp.
         /// </summary>
-        /// <param name="targetTime">The frame timestamp.</param>
+        /// <param name="time">The frame timestamp.</param>
         /// <returns>The decoded video frame.</returns>
-        public ImageData ReadFrame(TimeSpan targetTime)
+        public new ImageData GetFrame(TimeSpan time)
         {
-            lock (syncLock)
-            {
-                var frame = GetFrameByTimestamp(targetTime.ToTimestamp(Info.TimeBase));
-                return frame.ToBitmap(converter.Value, mediaOptions.VideoPixelFormat, outputFrameSize);
-            }
+            var frame = base.GetFrame(time) as VideoFrame;
+            return frame.ToBitmap(Converter.Value, Options.VideoPixelFormat, OutputFrameSize);
         }
 
         /// <summary>
@@ -154,201 +82,21 @@
         /// A <see langword="false"/> return value indicates that reached end of stream.
         /// The method throws exception if another error has occurred.
         /// </summary>
-        /// <param name="targetTime">The frame timestamp.</param>
+        /// <param name="time">The frame timestamp.</param>
         /// <param name="bitmap">The decoded video frame.</param>
         /// <returns><see langword="false"/> if reached end of the stream.</returns>
-        public bool TryReadFrame(TimeSpan targetTime, out ImageData bitmap)
+        public bool TryGetFrame(TimeSpan time, out ImageData bitmap)
         {
-            lock (syncLock)
+            try
             {
-                VideoFrame frame;
-                try
-                {
-                    frame = GetFrameByTimestamp(targetTime.ToTimestamp(Info.TimeBase));
-                }
-                catch (EndOfStreamException)
-                {
-                    bitmap = default;
-                    return false;
-                }
-
-                bitmap = frame.ToBitmap(converter.Value, mediaOptions.VideoPixelFormat, outputFrameSize);
+                bitmap = GetFrame(time);
                 return true;
             }
-        }
-
-        /// <summary>
-        /// Reads the video frame found at the specified timestamp.
-        /// A <see langword="false"/> return value indicates that reached end of stream.
-        /// The method throws exception if another error has occurred.
-        /// </summary>
-        /// <param name="targetTime">The frame timestamp.</param>
-        /// <param name="buffer">Pointer to the memory buffer.</param>
-        /// <param name="bufferStride">Number of bytes in a single row of pixel data.</param>
-        /// <returns><see langword="false"/> if reached end of the stream.</returns>
-        public bool TryReadFrameToPointer(TimeSpan targetTime, IntPtr buffer, int bufferStride)
-        {
-            lock (syncLock)
+            catch (EndOfStreamException)
             {
-                VideoFrame frame;
-                try
-                {
-                    frame = GetFrameByTimestamp(targetTime.ToTimestamp(Info.TimeBase));
-                }
-                catch (EndOfStreamException)
-                {
-                    return false;
-                }
-
-                CopyFrameToMemory(frame, buffer, bufferStride);
-                return true;
+                bitmap = default;
+                return false;
             }
-        }
-
-        /// <summary>
-        /// Reads the next frame from this stream.
-        /// </summary>
-        /// <returns>The decoded video frame.</returns>
-        public ImageData ReadNextFrame()
-        {
-            lock (syncLock)
-            {
-                var frame = GetNextFrame();
-                return frame.ToBitmap(converter.Value, mediaOptions.VideoPixelFormat, outputFrameSize);
-            }
-        }
-
-        /// <summary>
-        /// Reads the next frame from this stream.
-        /// A <see langword="false"/> return value indicates that reached end of stream.
-        /// The method throws exception if another error has occurred.
-        /// </summary>
-        /// <param name="bitmap">The decoded video frame.</param>
-        /// <returns><see langword="false"/> if reached end of the stream.</returns>
-        public bool TryReadNextFrame(out ImageData bitmap)
-        {
-            lock (syncLock)
-            {
-                VideoFrame frame;
-                try
-                {
-                    frame = GetNextFrame();
-                }
-                catch (EndOfStreamException)
-                {
-                    bitmap = default;
-                    return false;
-                }
-
-                bitmap = frame.ToBitmap(converter.Value, mediaOptions.VideoPixelFormat, outputFrameSize);
-                return true;
-            }
-        }
-
-        /// <summary>
-        /// Reads the next frame from this stream and writes the converted bitmap bytes directly to the provided buffer.
-        /// A <see langword="false"/> return value indicates that reached end of stream.
-        /// The method throws exception if another error has occurred.
-        /// </summary>
-        /// <param name="buffer">Pointer to the memory buffer.</param>
-        /// <param name="bufferStride">Number of bytes in a single row of pixel data.</param>
-        /// <returns><see langword="false"/> if reached end of the stream.</returns>
-        public bool TryReadNextFrameToPointer(IntPtr buffer, int bufferStride)
-        {
-            lock (syncLock)
-            {
-                VideoFrame frame;
-                try
-                {
-                    frame = GetNextFrame();
-                }
-                catch (EndOfStreamException)
-                {
-                    return false;
-                }
-
-                CopyFrameToMemory(frame, buffer, bufferStride);
-                return true;
-            }
-        }
-
-        /// <inheritdoc/>
-        void IDisposable.Dispose()
-        {
-            lock (syncLock)
-            {
-                stream.Dispose();
-
-                if (converter.IsValueCreated)
-                {
-                    converter.Value.Dispose();
-                }
-            }
-        }
-
-        private VideoFrame GetFrame(int frameNumber, int frameCount)
-        {
-            frameNumber = frameNumber.Clamp(0, frameCount != 0 ? frameCount - 1 : int.MaxValue);
-
-            if (frameNumber == FramePosition)
-            {
-                return GetNextFrame();
-            }
-            else if (frameNumber != FramePosition - 1)
-            {
-                var ts = frameNumber.ToTimestamp(Info.RealFrameRate, Info.TimeBase);
-
-                if (frameNumber < FramePosition || frameNumber > FramePosition + mediaOptions.VideoSeekThreshold)
-                {
-                    stream.OwnerFile.SeekFile(ts, Info.Index);
-                }
-
-                stream.SkipFrames(frameNumber.ToTimestamp(Info.RealFrameRate, Info.TimeBase));
-                FramePosition = frameNumber + 1;
-            }
-
-            return stream.RecentlyDecodedFrame as VideoFrame;
-        }
-
-        private VideoFrame GetFrameByTimestamp(long ts)
-        {
-            var frame = stream.RecentlyDecodedFrame;
-            ts = Math.Max(0, Math.Min(ts, Info.DurationRaw));
-
-            if (ts > frame.PresentationTimestamp && ts < frame.PresentationTimestamp + threshold)
-            {
-                return GetNextFrame();
-            }
-            else if (ts != frame.PresentationTimestamp)
-            {
-                if (ts < frame.PresentationTimestamp || ts >= frame.PresentationTimestamp + threshold)
-                {
-                    stream.OwnerFile.SeekFile(ts, Info.Index);
-                }
-
-                stream.SkipFrames(ts);
-                FramePosition = Position.ToFrameNumber(Info.RealFrameRate) + 1;
-            }
-
-            return stream.RecentlyDecodedFrame as VideoFrame;
-        }
-
-        private VideoFrame GetNextFrame()
-        {
-            var frame = stream.GetNextFrame();
-            FramePosition++;
-            return frame as VideoFrame;
-        }
-
-        private unsafe void CopyFrameToMemory(VideoFrame frame, IntPtr target, int stride)
-        {
-            if (stride != ImageData.EstimateStride(outputFrameSize.Width, mediaOptions.VideoPixelFormat))
-            {
-                throw new ArgumentOutOfRangeException(nameof(stride), "Stride does not match output bitmap size and pixel format.");
-            }
-
-            var ptr = (byte*)target.ToPointer();
-            converter.Value.AVFrameToBitmap(frame, ptr, stride);
         }
     }
 }

--- a/FFMediaToolkit/Decoding/VideoStreamInfo.cs
+++ b/FFMediaToolkit/Decoding/VideoStreamInfo.cs
@@ -1,0 +1,50 @@
+﻿namespace FFMediaToolkit.Decoding
+{
+    using System.Drawing;
+    using FFMediaToolkit.Common;
+    using FFMediaToolkit.Decoding.Internal;
+    using FFMediaToolkit.Helpers;
+    using FFmpeg.AutoGen;
+
+    /// <summary>
+    /// Represents informations about the video stream.
+    /// </summary>
+    public class VideoStreamInfo : StreamInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VideoStreamInfo"/> class.
+        /// </summary>
+        /// <param name="stream">A generic stream.</param>
+        /// <param name="container">The input container.</param>
+        internal unsafe VideoStreamInfo(AVStream* stream, InputContainer container)
+             : base(stream, MediaType.Video, container)
+        {
+            var codec = stream->codec;
+            IsInterlaced = codec->field_order != AVFieldOrder.AV_FIELD_PROGRESSIVE &&
+                           codec->field_order != AVFieldOrder.AV_FIELD_UNKNOWN;
+            FrameSize = new Size(codec->width, codec->height);
+            PixelFormat = codec->pix_fmt.FormatEnum(11);
+            AVPixelFormat = codec->pix_fmt;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the frames in the stream are interlaced.
+        /// </summary>
+        public bool IsInterlaced { get; }
+
+        /// <summary>
+        /// Gets the video frame dimensions.
+        /// </summary>
+        public Size FrameSize { get; }
+
+        /// <summary>
+        /// Gets a lowercase string representing the video pixel format.
+        /// </summary>
+        public string PixelFormat { get; }
+
+        /// <summary>
+        /// Gets the video pixel format.
+        /// </summary>
+        internal AVPixelFormat AVPixelFormat { get; }
+    }
+}

--- a/FFMediaToolkit/Encoding/AudioCodec.cs
+++ b/FFMediaToolkit/Encoding/AudioCodec.cs
@@ -1,0 +1,41 @@
+﻿namespace FFMediaToolkit.Encoding
+{
+    using FFmpeg.AutoGen;
+
+    /// <summary>
+    /// This enum contains only supported audio encoders.
+    /// If you want to use a codec not included to this enum, you can cast <see cref="AVCodecID"/> to <see cref="AudioCodec"/>.
+    /// </summary>
+    public enum AudioCodec
+    {
+        /// <summary>
+        /// Default audio codec for the selected container format.
+        /// </summary>
+        Default = AVCodecID.AV_CODEC_ID_NONE,
+
+        /// <summary>
+        /// AAC (Advanced Audio Coding) audio codec
+        /// </summary>
+        AAC = AVCodecID.AV_CODEC_ID_AAC,
+
+        /// <summary>
+        /// ATSC A/52A (AC-3) audio codec
+        /// </summary>
+        AC3 = AVCodecID.AV_CODEC_ID_AC3,
+
+        /// <summary>
+        /// MP3 (MPEG audio layer 3) audio codec
+        /// </summary>
+        MP3 = AVCodecID.AV_CODEC_ID_MP3,
+
+        /// <summary>
+        /// Windows Media Audio V2 audio codec
+        /// </summary>
+        WMA = AVCodecID.AV_CODEC_ID_WMAV2,
+
+        /// <summary>
+        /// OGG Vorbis audio codec
+        /// </summary>
+        Vorbis = AVCodecID.AV_CODEC_ID_VORBIS,
+    }
+}

--- a/FFMediaToolkit/Encoding/AudioEncoderSettings.cs
+++ b/FFMediaToolkit/Encoding/AudioEncoderSettings.cs
@@ -1,0 +1,67 @@
+﻿namespace FFMediaToolkit.Encoding
+{
+    using System.Collections.Generic;
+    using FFMediaToolkit.Audio;
+    using FFmpeg.AutoGen;
+
+    /// <summary>
+    /// Represents an audio encoder configuration.
+    /// </summary>
+    public class AudioEncoderSettings
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioEncoderSettings"/> class with default video settings values.
+        /// </summary>
+        /// <param name="sampleRate">The sample rate of the stream.</param>
+        /// <param name="channels">The number of channels in the stream.</param>
+        /// <param name="codec">The audio encoder.</param>
+        public AudioEncoderSettings(int sampleRate, int channels, AudioCodec codec = AudioCodec.Default)
+        {
+            SampleRate = sampleRate;
+            Channels = channels;
+            Codec = codec;
+            CodecOptions = new Dictionary<string, string>();
+        }
+
+        /// <summary>
+        /// Gets or sets the audio stream bitrate (bytes per second). The default value is 128,000 B/s.
+        /// </summary>
+        public int Bitrate { get; set; } = 128_000;
+
+        /// <summary>
+        /// Gets or sets the audio stream sample rate (samples per second). The default value is 44,100 samples/sec.
+        /// </summary>
+        public int SampleRate { get; set; } = 44_100;
+
+        /// <summary>
+        /// Gets or sets the number of channels in the audio stream. The default value is 2.
+        /// </summary>
+        public int Channels { get; set; } = 2;
+
+        /// <summary>
+        /// Gets or sets the number of samples per audio frame. Default is 2205 (1/20th of a second at 44.1kHz).
+        /// </summary>
+        public int SamplesPerFrame { get; set; } = 2205;
+
+        /// <summary>
+        /// Gets or the time base of the audio stream. Always equal to <see cref="SamplesPerFrame"/>/<see cref="SampleRate"/>.
+        /// </summary>
+        public AVRational TimeBase => new AVRational { num = SamplesPerFrame, den = SampleRate };
+
+        /// <summary>
+        /// Gets or sets the sample format to be used by the audio codec. The default value is <see cref="SampleFormat.SignedWord"/> (16-bit integer).
+        /// </summary>
+        public SampleFormat SampleFormat { get; set; } = SampleFormat.SignedWord;
+
+        /// <summary>
+        /// Gets or sets the dictionary with custom codec options.
+        /// </summary>
+        public Dictionary<string, string> CodecOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the codec for this stream.
+        /// If set to <see cref="AudioCodec.Default"/>, encoder will use default audio codec for current container.
+        /// </summary>
+        public AudioCodec Codec { get; set; }
+    }
+}

--- a/FFMediaToolkit/Encoding/AudioOutputStream.cs
+++ b/FFMediaToolkit/Encoding/AudioOutputStream.cs
@@ -23,7 +23,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="AudioOutputStream"/> class.
         /// </summary>
-        /// <param name="stream">The video stream.</param>
+        /// <param name="stream">The audio stream.</param>
         /// <param name="config">The stream setting.</param>
         internal AudioOutputStream(OutputStream<AudioFrame> stream, AudioEncoderSettings config)
         {
@@ -81,6 +81,8 @@
 
             stream.Push(converted);
             converted.Dispose();
+
+            lastFramePts = customPtsValue;
         }
 
         /// <summary>

--- a/FFMediaToolkit/Encoding/AudioOutputStream.cs
+++ b/FFMediaToolkit/Encoding/AudioOutputStream.cs
@@ -96,6 +96,8 @@
             frame.UpdateFromSampleData(samples);
             frame.PresentationTimestamp = customPtsValue;
             stream.Push(frame);
+
+            lastFramePts = customPtsValue;
         }
 
         /// <summary>

--- a/FFMediaToolkit/Encoding/AudioOutputStream.cs
+++ b/FFMediaToolkit/Encoding/AudioOutputStream.cs
@@ -1,0 +1,146 @@
+﻿namespace FFMediaToolkit.Encoding
+{
+    using System;
+    using FFMediaToolkit.Audio;
+    using FFMediaToolkit.Common.Internal;
+    using FFMediaToolkit.Encoding.Internal;
+    using FFMediaToolkit.Helpers;
+    using FFmpeg.AutoGen;
+
+    /// <summary>
+    /// Represents an audio encoder stream.
+    /// </summary>
+    public unsafe class AudioOutputStream : IDisposable
+    {
+        private readonly OutputStream<AudioFrame> stream;
+        private readonly AudioFrame frame;
+
+        private SwrContext* swrContext;
+
+        private bool isDisposed;
+        private long lastFramePts = -1;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioOutputStream"/> class.
+        /// </summary>
+        /// <param name="stream">The video stream.</param>
+        /// <param name="config">The stream setting.</param>
+        internal AudioOutputStream(OutputStream<AudioFrame> stream, AudioEncoderSettings config)
+        {
+            this.stream = stream;
+
+            long channelLayout = ffmpeg.av_get_default_channel_layout(config.Channels);
+            swrContext = ffmpeg.swr_alloc_set_opts(
+                null,
+                channelLayout,
+                (AVSampleFormat)config.SampleFormat,
+                config.SampleRate,
+                channelLayout,
+                (AVSampleFormat)SampleFormat.SingleP,
+                config.SampleRate,
+                0,
+                null);
+
+            ffmpeg.swr_init(swrContext);
+
+            Configuration = config;
+            frame = AudioFrame.Create(config.SampleRate, config.Channels, config.SamplesPerFrame, channelLayout, SampleFormat.SingleP);
+        }
+
+        /// <summary>
+        /// Gets the video encoding configuration used to create this stream.
+        /// </summary>
+        public AudioEncoderSettings Configuration { get; }
+
+        /// <summary>
+        /// Gets the current duration of this stream.
+        /// </summary>
+        public TimeSpan CurrentDuration => lastFramePts.ToTimeSpan(Configuration.TimeBase);
+
+        /// <summary>
+        /// Writes the specified audio data to the stream as the next frame.
+        /// </summary>
+        /// <param name="data">The audio data to write.</param>
+        /// <param name="customPtsValue">(optional) custom PTS value for the frame.</param>
+        public void AddFrame(AudioData data, long customPtsValue)
+        {
+            if (customPtsValue <= lastFramePts)
+                throw new Exception("Cannot add a frame that occurs chronologically before the most recently written frame!");
+
+            frame.UpdateFromAudioData(data);
+
+            var converted = AudioFrame.Create(
+                frame.SampleRate,
+                frame.NumChannels,
+                frame.NumSamples,
+                frame.ChannelLayout,
+                Configuration.SampleFormat);
+            converted.PresentationTimestamp = customPtsValue;
+
+            ffmpeg.swr_convert_frame(swrContext, converted.Pointer, frame.Pointer);
+
+            stream.Push(converted);
+            converted.Dispose();
+        }
+
+        /// <summary>
+        /// Writes the specified sample data to the stream as the next frame.
+        /// </summary>
+        /// <param name="samples">The sample data to write.</param>
+        /// <param name="customPtsValue">(optional) custom PTS value for the frame.</param>
+        public void AddFrame(float[][] samples, long customPtsValue)
+        {
+            if (customPtsValue <= lastFramePts)
+                throw new Exception("Cannot add a frame that occurs chronologically before the most recently written frame!");
+
+            frame.UpdateFromSampleData(samples);
+            frame.PresentationTimestamp = customPtsValue;
+            stream.Push(frame);
+        }
+
+        /// <summary>
+        /// Writes the specified audio data to the stream as the next frame.
+        /// </summary>
+        /// <param name="data">The audio data to write.</param>
+        /// <param name="customTime">Custom timestamp for this frame.</param>
+        public void AddFrame(AudioData data, TimeSpan customTime) => AddFrame(data, customTime.ToTimestamp(Configuration.TimeBase));
+
+        /// <summary>
+        /// Writes the specified audio data to the stream as the next frame.
+        /// </summary>
+        /// <param name="data">The audio data to write.</param>
+        public void AddFrame(AudioData data) => AddFrame(data, lastFramePts + 1);
+
+        /// <summary>
+        /// Writes the specified sample data to the stream as the next frame.
+        /// </summary>
+        /// <param name="samples">The sample data to write.</param>
+        /// <param name="customTime">Custom timestamp for this frame.</param>
+        public void AddFrame(float[][] samples, TimeSpan customTime) => AddFrame(samples, customTime.ToTimestamp(Configuration.TimeBase));
+
+        /// <summary>
+        /// Writes the specified sample data to the stream as the next frame.
+        /// </summary>
+        /// <param name="samples">The sample data to write.</param>
+        public void AddFrame(float[][] samples) => AddFrame(samples, lastFramePts + 1);
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (isDisposed)
+            {
+                return;
+            }
+
+            stream.Dispose();
+            frame.Dispose();
+
+            fixed (SwrContext** ptr = &swrContext)
+            {
+                ffmpeg.swr_free(ptr);
+            }
+
+            isDisposed = true;
+        }
+    }
+}

--- a/FFMediaToolkit/Encoding/Internal/OutputStreamFactory.cs
+++ b/FFMediaToolkit/Encoding/Internal/OutputStreamFactory.cs
@@ -33,7 +33,9 @@
                 throw new InvalidOperationException($"The {codecId} encoder doesn't support video!");
 
             var videoStream = ffmpeg.avformat_new_stream(container.Pointer, codec);
-            videoStream->time_base = new AVRational { num = config.FramerateRational.den, den = config.FramerateRational.num }; // frame rate (x/1) to time base (1/x) conversion;
+            videoStream->time_base = config.TimeBase;
+            videoStream->r_frame_rate = config.FramerateRational;
+
             var codecContext = videoStream->codec;
             codecContext->codec_id = codecId;
             codecContext->codec_type = AVMediaType.AVMEDIA_TYPE_VIDEO;
@@ -42,6 +44,7 @@
             codecContext->height = config.VideoHeight;
 
             codecContext->time_base = videoStream->time_base;
+            codecContext->framerate = videoStream->r_frame_rate;
             codecContext->gop_size = config.KeyframeRate;
             codecContext->pix_fmt = (AVPixelFormat)config.VideoFormat;
 

--- a/FFMediaToolkit/Encoding/Internal/OutputStreamFactory.cs
+++ b/FFMediaToolkit/Encoding/Internal/OutputStreamFactory.cs
@@ -74,5 +74,56 @@
 
             return new OutputStream<VideoFrame>(videoStream, container);
         }
+
+        /// <summary>
+        /// Creates a new audio stream for the specified <see cref="OutputContainer"/>.
+        /// </summary>
+        /// <param name="container">The media container.</param>
+        /// <param name="config">The stream settings.</param>
+        /// <returns>The new audio stream.</returns>
+        public static OutputStream<AudioFrame> CreateAudio(OutputContainer container, AudioEncoderSettings config)
+        {
+            var codecId = config.Codec == AudioCodec.Default ? container.Pointer->oformat->audio_codec : (AVCodecID)config.Codec;
+
+            if (codecId == AVCodecID.AV_CODEC_ID_NONE)
+                throw new InvalidOperationException("The media container doesn't support audio!");
+
+            var codec = ffmpeg.avcodec_find_encoder(codecId);
+
+            if (codec == null)
+                throw new InvalidOperationException($"Cannot find an encoder with the {codecId}!");
+
+            if (codec->type != AVMediaType.AVMEDIA_TYPE_AUDIO)
+                throw new InvalidOperationException($"The {codecId} encoder doesn't support audio!");
+
+            var audioStream = ffmpeg.avformat_new_stream(container.Pointer, codec);
+            var codecContext = audioStream->codec;
+
+            codecContext->time_base = config.TimeBase;
+
+            codecContext->codec_id = codecId;
+            codecContext->codec_type = AVMediaType.AVMEDIA_TYPE_AUDIO;
+
+            codecContext->bit_rate = config.Bitrate;
+            codecContext->sample_rate = config.SampleRate;
+            codecContext->frame_size = config.SamplesPerFrame;
+            codecContext->sample_fmt = (AVSampleFormat)config.SampleFormat;
+            codecContext->channels = config.Channels;
+            codecContext->channel_layout = (ulong)ffmpeg.av_get_default_channel_layout(config.Channels);
+
+            if ((container.Pointer->oformat->flags & ffmpeg.AVFMT_GLOBALHEADER) != 0)
+            {
+                codecContext->flags |= ffmpeg.AV_CODEC_FLAG_GLOBAL_HEADER;
+            }
+
+            var dict = new FFDictionary(config.CodecOptions);
+            var ptr = dict.Pointer;
+
+            ffmpeg.avcodec_open2(codecContext, codec, &ptr);
+
+            dict.Update(ptr);
+
+            return new OutputStream<AudioFrame>(audioStream, container);
+        }
     }
 }

--- a/FFMediaToolkit/Encoding/Internal/OutputStream{TFrame}.cs
+++ b/FFMediaToolkit/Encoding/Internal/OutputStream{TFrame}.cs
@@ -23,7 +23,7 @@
             : base(stream)
         {
             OwnerFile = owner;
-            packet = MediaPacket.AllocateEmpty(stream->index);
+            packet = MediaPacket.AllocateEmpty();
         }
 
         /// <summary>

--- a/FFMediaToolkit/Encoding/MediaBuilder.cs
+++ b/FFMediaToolkit/Encoding/MediaBuilder.cs
@@ -13,7 +13,6 @@
     {
         private readonly OutputContainer container;
         private readonly string outputPath;
-        private VideoEncoderSettings videoSettings;
 
         private MediaBuilder(string path, ContainerFormat? format)
         {
@@ -78,11 +77,19 @@
             }
 
             container.AddVideoStream(settings);
-            videoSettings = settings;
             return this;
         }
 
-        // TODO: Audio encoding (in v4.0 or v5.0 release)
+        /// <summary>
+        /// Adds a new audio stream to the file.
+        /// </summary>
+        /// <param name="settings">The video stream settings.</param>
+        /// <returns>This <see cref="MediaBuilder"/> object.</returns>
+        public MediaBuilder WithAudio(AudioEncoderSettings settings)
+        {
+            container.AddAudioStream(settings);
+            return this;
+        }
 
         /// <summary>
         /// Creates a multimedia file for specified video stream.
@@ -92,7 +99,7 @@
         {
             container.CreateFile(outputPath);
 
-            return new MediaOutput(container, videoSettings);
+            return new MediaOutput(container);
         }
     }
 }

--- a/FFMediaToolkit/Encoding/MediaOutput.cs
+++ b/FFMediaToolkit/Encoding/MediaOutput.cs
@@ -20,11 +20,11 @@
         {
             container = mediaContainer;
 
-            Video = container.Video
+            VideoStreams = container.Video
                 .Select(o => new VideoOutputStream(o.stream, o.config))
                 .ToArray();
 
-            Audio = container.Audio
+            AudioStreams = container.Audio
                 .Select(o => new AudioOutputStream(o.stream, o.config))
                 .ToArray();
         }
@@ -37,12 +37,22 @@
         /// <summary>
         /// Gets the video streams in the media file.
         /// </summary>
-        public VideoOutputStream[] Video { get; }
+        public VideoOutputStream[] VideoStreams { get; }
 
         /// <summary>
-        /// Gets the video streams in the media file.
+        /// Gets the audio streams in the media file.
         /// </summary>
-        public AudioOutputStream[] Audio { get; }
+        public AudioOutputStream[] AudioStreams { get; }
+
+        /// <summary>
+        /// Gets the first video stream in the media file.
+        /// </summary>
+        public VideoOutputStream Video => VideoStreams.FirstOrDefault();
+
+        /// <summary>
+        /// Gets the first audio stream in the media file.
+        /// </summary>
+        public AudioOutputStream Audio => AudioStreams.FirstOrDefault();
 
         /// <inheritdoc/>
         public void Dispose()

--- a/FFMediaToolkit/Encoding/MediaOutput.cs
+++ b/FFMediaToolkit/Encoding/MediaOutput.cs
@@ -1,7 +1,7 @@
 ﻿namespace FFMediaToolkit.Encoding
 {
     using System;
-    using FFMediaToolkit.Common;
+    using System.Linq;
     using FFMediaToolkit.Encoding.Internal;
 
     /// <summary>
@@ -16,15 +16,17 @@
         /// Initializes a new instance of the <see cref="MediaOutput"/> class.
         /// </summary>
         /// <param name="mediaContainer">The <see cref="OutputContainer"/> object.</param>
-        /// <param name="videoSettings">The video stream settings.</param>
-        internal MediaOutput(OutputContainer mediaContainer, VideoEncoderSettings videoSettings)
+        internal MediaOutput(OutputContainer mediaContainer)
         {
             container = mediaContainer;
 
-            if (mediaContainer.Video != null)
-            {
-                Video = new VideoOutputStream(mediaContainer.Video, videoSettings);
-            }
+            Video = container.Video
+                .Select(o => new VideoOutputStream(o.stream, o.config))
+                .ToArray();
+
+            Audio = container.Audio
+                .Select(o => new AudioOutputStream(o.stream, o.config))
+                .ToArray();
         }
 
         /// <summary>
@@ -33,14 +35,14 @@
         ~MediaOutput() => Dispose();
 
         /// <summary>
-        /// Gets the video stream in the media file.
+        /// Gets the video streams in the media file.
         /// </summary>
-        public VideoOutputStream Video { get; }
+        public VideoOutputStream[] Video { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the media file contains video stream.
+        /// Gets the video streams in the media file.
         /// </summary>
-        public bool HasVideo => Video != null;
+        public AudioOutputStream[] Audio { get; }
 
         /// <inheritdoc/>
         public void Dispose()

--- a/FFMediaToolkit/Encoding/VideoEncoderSettings.cs
+++ b/FFMediaToolkit/Encoding/VideoEncoderSettings.cs
@@ -1,7 +1,7 @@
 ﻿namespace FFMediaToolkit.Encoding
 {
     using System.Collections.Generic;
-    using FFMediaToolkit.Common;
+
     using FFMediaToolkit.Graphics;
     using FFmpeg.AutoGen;
 
@@ -66,6 +66,11 @@
         /// Gets or sets the video frame rate as a FFmpeg <see cref="AVRational"/> value. Optional. Overwrites <see cref="Framerate"/> property.
         /// </summary>
         public AVRational FramerateRational { get; set; }
+
+        /// <summary>
+        /// Gets the calculated time base for the video stream. Value is always equal to reciporical of <see cref="FramerateRational"/>.
+        /// </summary>
+        public AVRational TimeBase => new AVRational { num = FramerateRational.den, den = FramerateRational.num };
 
         /// <summary>
         /// Gets or sets the Constant Rate Factor. It supports only H.264 and H.265 codecs.

--- a/FFMediaToolkit/Encoding/VideoOutputStream.cs
+++ b/FFMediaToolkit/Encoding/VideoOutputStream.cs
@@ -58,6 +58,8 @@
             encodedFrame.UpdateFromBitmap(frame, converter);
             encodedFrame.PresentationTimestamp = customPtsValue;
             stream.Push(encodedFrame);
+
+            lastFramePts = customPtsValue;
         }
 
         /// <summary>

--- a/FFMediaToolkit/FFMediaToolkit.csproj
+++ b/FFMediaToolkit/FFMediaToolkit.csproj
@@ -7,9 +7,9 @@
     <Authors>Radosław Kmiotek</Authors>
     <Company>radek-k</Company>
     <Copyright>Copyright (c) 2019-2020 Radosław Kmiotek</Copyright>
-    <Description>FFMediaToolkit is a cross-platform video decoder/encoder library for .NET that uses FFmpeg native libraries. It supports video frames extraction (fast access to any frame by index or timestamp), reading file metadata and creating videos from bitmap images.</Description>
+    <Description>FFMediaToolkit is a cross-platform .NET library for decoding/encoding video using FFmpeg native libraries. It supports video frames extraction (fast access to any frame by index or timestamp), reading file metadata and creating videos from bitmap images.</Description>
     <PackageTags>ffmpeg;video;encoder;encoding;decoder;decoding;h264;mp4;c#;netstandard;netcore;frame-extraction</PackageTags>
-    <VersionPrefix>3.1.1</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <RepositoryUrl>https://github.com/radek-k/FFMediaToolkit</RepositoryUrl>
     <PackageProjectUrl>https://github.com/radek-k/FFMediaToolkit</PackageProjectUrl>
     <PackageLicenseFile></PackageLicenseFile>

--- a/FFMediaToolkit/FFmpegLoader.cs
+++ b/FFMediaToolkit/FFmpegLoader.cs
@@ -80,6 +80,12 @@
         public static bool? IsFFmpegGplLicensed { get; private set; }
 
         /// <summary>
+        /// Gets the FFmpeg license text
+        /// Empty when FFmpeg libraries were not yet loaded.
+        /// </summary>
+        public static string FFmpegLicense { get; private set; } = string.Empty;
+
+        /// <summary>
         /// Gets a value indicating whether the FFmpeg binary files were successfully loaded.
         /// </summary>
         internal static bool IsFFmpegLoaded { get; private set; }
@@ -111,7 +117,7 @@
                 catch (DirectoryNotFoundException)
                 {
                     throw new DirectoryNotFoundException("Cannot found the default FFmpeg directory.\n" +
-                        "On Windows you have to specify a path to a directory containing the FFmpeg shared build DLL files\n" +
+                        "On Windows you have to set \"FFmpegLoader.FFmpegPath\" with full path to the directory containing FFmpeg shared build \".dll\" files\n" +
                         "For more informations please see https://github.com/radek-k/FFMediaToolkit#setup");
                 }
             }
@@ -119,7 +125,8 @@
             try
             {
                 FFmpegVersion = ffmpeg.av_version_info();
-                IsFFmpegGplLicensed = ffmpeg.avcodec_license().StartsWith("GPL");
+                FFmpegLicense = ffmpeg.avcodec_license();
+                IsFFmpegGplLicensed = FFmpegLicense.StartsWith("GPL");
             }
             catch (DllNotFoundException ex)
             {
@@ -160,7 +167,7 @@
         /// <param name="exception">The original exception.</param>
         internal static void HandleLibraryLoadError(Exception exception)
         {
-            throw new DllNotFoundException($"Cannot load required FFmpeg libraries from {FFmpegPath} directory.\nFor more informations please see https://github.com/radek-k/FFMediaToolkit#setup", exception);
+            throw new DllNotFoundException($"Cannot load required FFmpeg libraries from {FFmpegPath} directory.\nMake sure the \"Build\"Prefer 32-bit\" option in the project settings is turned off.\nFor more informations please see https://github.com/radek-k/FFMediaToolkit#setup", exception);
         }
     }
 }

--- a/FFMediaToolkit/Helpers/Extensions.cs
+++ b/FFMediaToolkit/Helpers/Extensions.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.ComponentModel;
-    using FFMediaToolkit.Common.Internal;
+    using FFMediaToolkit.Common;
     using FFmpeg.AutoGen;
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -1,117 +1,109 @@
 # FFMediaToolkit
 
-[![Build status](https://ci.appveyor.com/api/projects/status/9vaaqchtx1d5nldj?svg=true)](https://ci.appveyor.com/project/radek41/ffmediatoolkit) [![Nuget](https://img.shields.io/nuget/v/FFMediaToolkit.svg)](https://www.nuget.org/packages/FFMediaToolkit/)
+[![Build status](https://ci.appveyor.com/api/projects/status/9vaaqchtx1d5nldj?svg=true)](https://ci.appveyor.com/project/radek-k/ffmediatoolkit) [![Nuget](https://img.shields.io/nuget/v/FFMediaToolkit.svg)](https://www.nuget.org/packages/FFMediaToolkit/)
 [![License](https://img.shields.io/github/license/radek-k/FFMediaToolkit.svg)](https://github.com/radek-k/FFMediaToolkit/blob/master/LICENSE)
 
-**FFMediaToolkit** is a **cross-platform** **.NET Standard** library for **creating and reading video files**. It uses native **FFmpeg** libraries by the [FFmpeg.Autogen](https://github.com/Ruslan-B/FFmpeg.AutoGen) bindings.
+**FFMediaToolkit** is a .NET library for creating and reading video files. It uses native FFmpeg libraries by the [FFmpeg.Autogen](https://github.com/Ruslan-B/FFmpeg.AutoGen) bindings.
 
 ## Features
 
-- **Decoding/encoding videos** in almost any format supported by FFmpeg.
-- **Fast<sup id="a1">[1](#f1)</sup>, frame accurate access to any video frame** by frame index<sup id="a1">[2](#f1)</sup> or timestamp.
-- **Creating videos from images** with metadata, pixel format, bitrate, CRF, FPS, GoP, dimensions and other codec settings.
-- **Compatible with most of .NET graphics libraries**<sup id="a1">[3](#f1)</sup>.
+- Decoding/encoding videos in many formats supported by FFmpeg.
+- Access to any video frame by frame index<sup id="a1">[2](#f1)</sup> or timestamp.
+- Creating videos from images with metadata, pixel format, bitrate, CRF, FPS, GoP, dimensions and other codec settings.
 - Supports reading multimedia chapters and metadata.
-- **Simple, object-oriented, easy-to-use API** with inline documentation.
-- **Cross-platform** - works on **Linux**, **Windows** and **MacOS** - with **.NET Core** or **.NET Framework** projects.
+- Cross-platform - works on Linux, Windows, and macOS - with .NET Core or .NET Framework projects.
+
 _____
+
 <b id="f1">1</b> The time it takes to obtain a frame depends on the number of keyframes in the video stream(see https://en.wikipedia.org/wiki/Key_frame#Video_compression)  
-<b id="f1">2</b> Access to frame by index is not supported in Variable Frame Rate videos.  
-<b id="f3">3</b> See the [usage details](https://github.com/radek-k/FFMediaToolkit#usage-details)
+<b id="f1">2</b> Access to frame by index **is not supported** in Variable Frame Rate videos.
+
 ## Code samples
 
 - Extract all video frames as PNG files
-
-    ````c#
+  
+    ```c#
+    int i = 0;
     var file = MediaFile.Open(@"C:\videos\movie.mp4");
-    for (int i = 0; i < file.Video.Info.FrameCount; i++)
+    while(file.Video.TryReadNextFrame(out var imageData))
     {
-        file.Video.ReadFrame(i).ToBitmap().Save($@"C:\images\frame_{i}.png");
+        imageData.ToBitmap().Save($@"C:\images\frame_{i++}.png");
         // See the #Usage details for example .ToBitmap() implementation
         // The .Save() method may be different depending on your graphics library
     }
-    ````
-- Video decoding
+    ```
 
-    ````c#
+- Video decoding
+  
+    ```c#
     // Opens a multimedia file.
     // You can use the MediaOptions properties to set decoder options.
     var file = MediaFile.Open(@"C:\videos\movie.mp4");
+    
+     // Gets the frame at 5th second of the video.
+    var frame5s = file.Video.ReadFrame(TimeSpan.FromSeconds(5));
     
     // Print informations about the video stream.
     Console.WriteLine($"Bitrate: {file.Info.Bitrate / 1000.0} kb/s");
     var info = file.Video.Info;
     Console.WriteLine($"Duration: {info.Duration}");
-    var isFrameCountAccurate = info.IsFrameCountProvidedByContainer || !info.IsVariableFrameRate;
-    var frameCount = isFrameCountAccurate ? info.FrameCount.ToString() : "N/A";
-    Console.WriteLine($"Frames count: {frameCount}");
+    Console.WriteLine($"Frames count: {info.NumberOfFrames ?? "N/A"}");
     var frameRateInfo = info.IsVariableFrameRate ? "average" : "constant";
     Console.WriteLine($"Frame rate: {info.AvgFrameRate} fps ({frameRateInfo})");
     Console.WriteLine($"Frame size: {info.FrameSize}");
     Console.WriteLine($"Pixel format: {info.PixelFormat}");
     Console.WriteLine($"Codec: {info.CodecName}");
     Console.WriteLine($"Is interlaced: {info.IsInterlaced}");
-
-    // Gets a frame by its number.
-    var frame102 = file.Video.ReadFrame(frameNumber: 102);
-
-    // Gets the frame at 5th second of the video.
-    var frame5s = file.Video.ReadFrame(TimeSpan.FromSeconds(5));
-    ````
+    ```
 
 - Encode video from images.
-    
-    ````c#
+  
+    ```c#
     // You can set there codec, bitrate, frame rate and many other options.
     var settings = new VideoEncoderSettings(width: 1920, height: 1080, framerate: 30, codec: VideoCodec.H264);
     settings.EncoderPreset = EncoderPreset.Fast;
     settings.CRF = 17;
-    var file = MediaBuilder.CreateContainer(@"C:\videos\example.mp4").WithVideo(settings).Create();
-    while(file.Video.FramesCount < 300)
+    using(var file = MediaBuilder.CreateContainer(@"C:\videos\example.mp4").WithVideo(settings).Create())
     {
-        file.Video.AddFrame(/*Your code*/);
+        while(file.Video.FramesCount < 300)
+        {
+            file.Video.AddFrame(/*Your code*/);
+        }
     }
-    file.Dispose(); // MediaOutput ("file" variable) must be disposed when encoding is completed. You can use `using() { }` block instead.
-    ````
+    ```
 
 ## Setup
 
-- Install the **FFMediaToolkit** package from [NuGet](https://www.nuget.org/packages/FFMediaToolkit/).
+Install the **FFMediaToolkit** package from [NuGet](https://www.nuget.org/packages/FFMediaToolkit/).
 
-    ````shell
-    dotnet add package FFMediaToolkit
-    ````
+```shell
+dotnet add package FFMediaToolkit
+```
+  
+```Package
+PM> Install-Package FFMediaToolkit
+```
 
-    ````Package Manager Console
-    PM> Install-Package FFMediaToolkit
-    ````
+**FFmpeg libraries are not included in the package.** To use FFMediaToolkit, you need the **FFmpeg shared build** binaries: `avcodec`, `avformat`, `avutil`, `swresample`, `swscale`.
 
-> **FFmpeg libraries are not included with the package.** To use FFMediaToolkit, you need the **latest FFmpeg (>= v4.2) shared build** binaries. You can download it from the [Zeranoe FFmpeg](https://ffmpeg.zeranoe.com/builds/) site or build your own.
+- **Windows** - You can download it from the [BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds/releases) or [gyan.dev](https://www.gyan.dev/ffmpeg/builds/). You only need `*.dll` files from the `.\bin` directory (**not `.\lib`**) of the ZIP package. Place the binaries in the `.\ffmpeg\x86_64\`(64bit) in the application output directory or set `FFmpegLoader.FFmpegPath`.
+- **Linux** - Download FFmpeg using your package manager.
+- **macOS** - Install FFmpeg via [Homebrew](https://formulae.brew.sh/formula/ffmpeg).`
 
-> FFmpeg libraries must have the same architecture as your project. If you want to use 64-bit FFmpeg, you should disable the *Build* -> *Prefer 32-bit* option in Visual Studio project properties.
-- Required FFmpeg binaries (dll/so/dylib):
-  - **avcodec** v58
-  - **avformat** v58
-  - **avutil** v56
-  - **swresample** v3
-  - **swscale** v5
-- FFmpeg setup:
-  - **Windows** - Place the binaries in the `.\ffmpeg\x86\` (32 bit) and `.\ffmpeg\x86_64\`(64bit) in the application output directory.
-  - **Linux** - FFmpeg is pre-installed on many desktop Linux systems. The default path is `/usr/lib/x86` (`_64`) `-linux-gnu/`.
-  - **MacOS** - You can install FFmpeg via MacPorts or download `.dylib` files from the [Zeranoe](https://ffmpeg.zeranoe.com/builds/) site. The default path is `/opt/local/lib/`.
-
-  If you want to **use other directory**, you can **specify a path to it** by the  `FFmpegLoader.FFmpegPath` property.
+**You need to set `FFmpegLoader.FFmpegPath` with a full path to FFmpeg libraries.**
+> If you want to use 64-bit FFmpeg, you have to disable the *Build* -> *Prefer 32-bit* option in Visual Studio project properties.
 
 ## Usage details
 
-FFMediaToolkit uses the [*ref struct*](https://docs.microsoft.com/pl-pl/dotnet/csharp/language-reference/keywords/ref#ref-struct-types) `ImageData` for bitmap images. The `.Data` property contains pixels data in a [`Span<byte>`](https://docs.microsoft.com/pl-pl/dotnet/api/system.span-1?view=netstandard-2.1). 
-> **If you want to process or save the `ImageData`, you should convert it to another graphics object using the following methods.**
+FFMediaToolkit uses the [*ref struct*](https://docs.microsoft.com/pl-pl/dotnet/csharp/language-reference/keywords/ref#ref-struct-types) `ImageData` for bitmap images. The `.Data` property contains pixels data in a [`Span<byte>`](https://docs.microsoft.com/pl-pl/dotnet/api/system.span-1?view=netstandard-2.1).
 
-> **These methods are not included in the program to avoid additional dependencies and provide compatibility with many graphic libraries.**
+> **If you want to process or save the `ImageData`, you should convert it to another graphics object, using one of the following methods.**
+
+> **These methods are not included in the program to avoid additional dependencies and provide compatibility with many graphics libraries.**
 
 - **For [ImageSharp](https://github.com/SixLabors/ImageSharp) library (.NET Standard/Core - cross-platform):**
-
-    ````c#
+  
+    ```c#
     using SixLabors.ImageSharp;
     using SixLabors.ImageSharp.PixelFormats;
     ...
@@ -119,11 +111,11 @@ FFMediaToolkit uses the [*ref struct*](https://docs.microsoft.com/pl-pl/dotnet/c
     {
         return Image.LoadPixelData<Bgr24>(imageData.Data, imageData.ImageSize.Width, imageData.ImageSize.Height);
     }
-    ````
+    ```
 
 - **For .NET Framework `System.Drawing.Bitmap` (Windows only):**
-
-    ````c#
+  
+    ```c#
     // ImageData -> Bitmap (unsafe)
     public static unsafe Bitmap ToBitmap(this ImageData bitmap)
     {
@@ -132,22 +124,22 @@ FFMediaToolkit uses the [*ref struct*](https://docs.microsoft.com/pl-pl/dotnet/c
             return new Bitmap(bitmap.ImageSize.Width, bitmap.ImageSize.Height, bitmap.Stride, PixelFormat.Format24bppRgb, new IntPtr(bitmap.Data));
         }
     }
-
+  
     // Bitmap -> ImageData (safe)
     public static ImageData ToImageData(this Bitmap bitmap)
     {
         var rect = new Rectangle(Point.Empty, bitmap.Size);
         var bitLock = bitmap.LockBits(rect, ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb);
-
+  
         var bitmapData = ImageData.FromPointer(bitLock.Scan0, bitmap.Size, ImagePixelFormat.Bgr24);
         bitmap.UnlockBits(bitLock);
         return bitmapData;
     }
-    ````
+    ```
 
 - **For .NET Framework/Core desktop apps with WPF UI. (Windows only):**
-
-    ````c#
+  
+    ```c#
     using System.Windows.Media.Imaging;
     ...
     // ImageData -> BitmapSource (unsafe)
@@ -158,16 +150,35 @@ FFMediaToolkit uses the [*ref struct*](https://docs.microsoft.com/pl-pl/dotnet/c
             return BitmapSource.Create(bitmapData.ImageSize.Width, bitmapData.ImageSize.Height, 96, 96, PixelFormats.Bgr32, null, new IntPtr(ptr), bitmapData.Data.Length, bitmapData.Stride);
         }
     }
-
+  
     // BitmapSource -> ImageData (safe)
     public static ImageData ToImageData(this BitmapSource bitmap)
     {
         var wb = new WriteableBitmap(bitmap);
         return ImageData.FromPointer(wb.BackBuffer, ImagePixelFormat.Bgra32, wb.PixelWidth, wb.PixelHeight);
     }
-    ````
+    ```
+
 - **FFMediaToolkit will also work with any other graphics library that supports creating images from `Span<byte>`, byte array or memory pointer**
 
+## Visual Basic usage
+Writing decoded bitmap directly to the WPF `WriteableBitmap` buffer using the `TryReadFrameToPointer` method:
+````vb
+Dim file As FileStream = New FileStream("path to the video file", FileMode.Open, FileAccess.Read)
+Dim media As MediaFile = MediaFile.Load(file)
+Dim bmp As WriteableBimap = New WriteableBitmap(media.Video.Info.FrameSize.Width, media.Video.Info.FrameSize.Height, 96, 96, PixelFormats.Bgr24, Nothing)
+bmp.Lock()
+Dim decoded As Boolean = media.Video.TryReadFrameToPointer(TimeSpan.FromMinutes(1), bmp.BackBuffer, bmp.BackBufferStride)
+If decoded Then
+    bmp.AddDirtyRect(New Int32Rect(0, 0, media.Video.Info.FrameSize.Width, media.Video.Info.FrameSize.Height))
+End If
+bmp.Unlock()
+imageBox.Source = bmp
+````
+Converting `ImageData` to a byte array:
+````vb
+Dim data() As Byte = media.Video.ReadNextFrame().Data.ToArray()
+````
 ## Licensing
 
 This project is licensed under the [MIT](https://github.com/radek-k/FFMediaToolkit/blob/master/LICENSE) license.


### PR DESCRIPTION
This pull request aims to get FFMediaToolkit a few steps closer to a solution for #33.

A couple months ago @kskalski started an implementation of audio stream reading (#48).  However, they did leave a few notes about key missing features of the implementation.  The most prevalent of these were proper handling of interleaved audio/video data and write support for audio streams.  

After some brief deliberation and research about the ffmpeg api, I am ready to begin an implementation of both of these features.  

One other feature I will also consider adding is support for multiple audio streams, as I believe it is pretty limiting to allow for either one video stream, one audio stream, or both, but not more than one each.  

I will post updates to this thread as I make progress.