### PR TITLE
Fix System.AccessViolationException in InputContainer.OnDisposing

### DIFF
--- a/FFMediaToolkit/Decoding/Internal/InputContainer.cs
+++ b/FFMediaToolkit/Decoding/Internal/InputContainer.cs
@@ -113,12 +113,6 @@
 
             var ptr = Pointer;
             ffmpeg.avformat_close_input(&ptr);
-
-            if (Pointer->pb != null && Pointer->pb->buffer != null)
-            {
-                ffmpeg.av_free(Pointer->pb->buffer);
-                ffmpeg.avio_context_free(&Pointer->pb);
-            }
         }
 
         private static InputContainer MakeContainer(string url, MediaOptions options, AVFormatContextDelegate contextDelegate)


### PR DESCRIPTION
I get a random System.AccessViolationException in the InputContainer.OnDisposing. I have a media file I open and close semi frequently to grab a single frame from.

I see you're getting around `avformat_close_input` setting the input to null by passing it a copy of the pointer and not a real one. This is so you can free those other resources in the section I'm removing with this commit.

The [FFmpeg docs](https://ffmpeg.org/doxygen/2.2/group__lavf__decoding.html#gae804b99aec044690162b8b9b110236a4) say that `avformat_close_input` frees the AVFormatContext and all its contents. Those pointers are dangling and should be set null in FFmpeg but are not. This crash pops up because that memory has already been freed.

`avformat_close_input`  [calls](https://ffmpeg.org/doxygen/2.2/libavformat_2utils_8c_source.html#l03570) `avio_close` at the end which in turns [frees the buffer and pb](https://ffmpeg.org/doxygen/2.2/aviobuf_8c_source.html#l00880) which are you attempting to delete.

By removing this bit I fix my crash and resolves the issues with deleting the AVFormatContext 