### PR TITLE
Return EOF when end of the stream has been reached

### DIFF
--- a/FFMediaToolkit/Decoding/Internal/AvioStream.cs
+++ b/FFMediaToolkit/Decoding/Internal/AvioStream.cs
@@ -40,10 +40,13 @@
             }
 
             int readed = inputStream.Read(readBuffer, 0, readBuffer.Length);
-            if (readed > 0)
+
+            if (readed < 1)
             {
-                Marshal.Copy(readBuffer, 0, (IntPtr)buffer, readed);
+                return ffmpeg.AVERROR_EOF;
             }
+
+            Marshal.Copy(readBuffer, 0, (IntPtr)buffer, readed);
 
             return readed;
         }


### PR DESCRIPTION
This resolves issue when ReadPacket stuck at frame reading when container have multiple video streams. 
It's only reproduced for MediaFile.Open(Stream) with latest release.

A sample video, that contains two video streams:
https://files.catbox.moe/702qmb.webm