### PR TITLE
Implement support for FFmpeg 7.1

### DIFF
--- a/FFMediaToolkit/Common/Internal/ImageConverter.cs
+++ b/FFMediaToolkit/Common/Internal/ImageConverter.cs
@@ -1,6 +1,5 @@
 ﻿namespace FFMediaToolkit.Common.Internal
 {
-    using System;
     using System.Drawing;
     using FFMediaToolkit.Graphics;
     using FFmpeg.AutoGen;
@@ -13,12 +12,13 @@
         // sws_scale requires up to 16 extra bytes allocated in the input buffer when resizing an image
         // (reference: https://www.ffmpeg.org/doxygen/6.0/frame_8h_source.html#l00340)
         private const int BufferPaddingSize = 16;
-        private byte[] tmpBuffer = { };
 
         private readonly Size destinationSize;
         private readonly AVPixelFormat destinationFormat;
+
         private Size lastSourceSize;
         private AVPixelFormat lastSourcePixelFormat;
+        private byte[] tmpBuffer = { };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImageConverter"/> class.

--- a/FFMediaToolkit/Common/Wrapper{T}.cs
+++ b/FFMediaToolkit/Common/Wrapper{T}.cs
@@ -28,6 +28,11 @@
         /// </summary>
         public T* Pointer => isDisposed ? null : (T*)pointer;
 
+        /// <summary>
+        /// Gets a reference to the wrapped pointer field.
+        /// </summary>
+        protected ref readonly IntPtr PointerRef => ref pointer;
+
         /// <inheritdoc/>
         public void Dispose() => Disposing(true);
 

--- a/FFMediaToolkit/Common/Wrapper{T}.cs
+++ b/FFMediaToolkit/Common/Wrapper{T}.cs
@@ -31,7 +31,7 @@
         /// <summary>
         /// Gets a reference to the wrapped pointer field.
         /// </summary>
-        protected ref readonly IntPtr PointerRef => ref pointer;
+        internal ref readonly IntPtr PointerRef => ref pointer;
 
         /// <inheritdoc/>
         public void Dispose() => Disposing(true);

--- a/FFMediaToolkit/Decoding/Internal/Decoder.cs
+++ b/FFMediaToolkit/Decoding/Internal/Decoder.cs
@@ -133,7 +133,10 @@
         protected override void OnDisposing()
         {
             RecentlyDecodedFrame.Dispose();
-            ffmpeg.avcodec_close(Pointer);
+            fixed (void* pointerRef = &PointerRef)
+            {
+                ffmpeg.avcodec_free_context((AVCodecContext**)pointerRef);
+            }
         }
 
         private void ReadNextFrame()

--- a/FFMediaToolkit/Decoding/Internal/DecoderFactory.cs
+++ b/FFMediaToolkit/Decoding/Internal/DecoderFactory.cs
@@ -33,10 +33,12 @@
                 .ThrowIfError("Cannot open the stream codec!");
             codecContext->pkt_timebase = stream->time_base;
 
-            var dict = new FFDictionary(options.DecoderOptions, false).Pointer;
-
-            ffmpeg.avcodec_open2(codecContext, codec, &dict)
-                .ThrowIfError("Cannot open the stream codec!");
+            var dict = new FFDictionary(options.DecoderOptions, false);
+            fixed (void* dictPtrRef = &dict.PointerRef)
+            {
+                ffmpeg.avcodec_open2(codecContext, codec, (AVDictionary**)dictPtrRef)
+                    .ThrowIfError("Cannot open the stream codec!");
+            }
 
             return new Decoder(codecContext, stream, container);
         }

--- a/FFMediaToolkit/Decoding/MediaOptions.cs
+++ b/FFMediaToolkit/Decoding/MediaOptions.cs
@@ -34,12 +34,13 @@
     public class MediaOptions
     {
         private const string Threads = "threads";
-        private const string Auto = "auto";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MediaOptions"/> class.
         /// </summary>
-        public MediaOptions() => DecoderThreads = null;
+        public MediaOptions()
+        {
+        }
 
         /// <summary>
         /// Gets or sets the limit of memory used by the packet buffer. Default limit is 40 MB per stream.
@@ -76,8 +77,19 @@
         /// </summary>
         public int? DecoderThreads
         {
-            get => int.TryParse(DecoderOptions[Threads], out var count) ? (int?)count : null;
-            set => DecoderOptions[Threads] = value.HasValue ? value.ToString() : Auto;
+            get => DecoderOptions.TryGetValue(Threads, out string value) &&
+                int.TryParse(value, out var count) ? (int?)count : null;
+            set
+            {
+                if (value.HasValue)
+                {
+                    DecoderOptions[Threads] = value.ToString();
+                }
+                else
+                {
+                    DecoderOptions.Remove(Threads);
+                }
+            }
         }
 
         /// <summary>

--- a/FFMediaToolkit/Decoding/VideoStreamInfo.cs
+++ b/FFMediaToolkit/Decoding/VideoStreamInfo.cs
@@ -28,7 +28,7 @@
             PixelFormat = ((AVPixelFormat)codec->format).FormatEnum(11);
             AVPixelFormat = (AVPixelFormat)codec->format;
 
-            var matrix = (IntPtr)ffmpeg.av_stream_get_side_data(stream, AVPacketSideDataType.AV_PKT_DATA_DISPLAYMATRIX, null);
+            var matrix = (IntPtr)ffmpeg.av_packet_side_data_get(codec->coded_side_data, codec->nb_coded_side_data, AVPacketSideDataType.AV_PKT_DATA_DISPLAYMATRIX);
             Rotation = CalculateRotation(matrix);
         }
 

--- a/FFMediaToolkit/Encoding/Internal/OutputStream{TFrame}.cs
+++ b/FFMediaToolkit/Encoding/Internal/OutputStream{TFrame}.cs
@@ -1,5 +1,7 @@
 ﻿namespace FFMediaToolkit.Encoding.Internal
 {
+    using System;
+    using System.Runtime.CompilerServices;
     using FFMediaToolkit.Common;
     using FFMediaToolkit.Common.Internal;
     using FFMediaToolkit.Helpers;
@@ -13,7 +15,7 @@
         where TFrame : MediaFrame
     {
         private readonly MediaPacket packet;
-        private AVCodecContext* codecContext;
+        private readonly AVCodecContext* codecContext;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OutputStream{TFrame}"/> class.
@@ -70,9 +72,10 @@
             FlushEncoder();
             packet.Dispose();
 
-            ffmpeg.avcodec_close(codecContext);
-            ffmpeg.av_free(codecContext);
-            codecContext = null;
+            fixed (AVCodecContext** codecContextRef = &codecContext)
+            {
+                ffmpeg.avcodec_free_context(codecContextRef);
+            }
         }
 
         private void FlushEncoder()

--- a/FFMediaToolkit/FFMediaToolkit.csproj
+++ b/FFMediaToolkit/FFMediaToolkit.csproj
@@ -3,10 +3,11 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+	  <Nullable>disable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Radosław Kmiotek</Authors>
     <Company>radek-k</Company>
-    <Copyright>Copyright (c) 2019-2023 Radosław Kmiotek</Copyright>
+    <Copyright>Copyright (c) 2019-2025 Radosław Kmiotek</Copyright>
     <Description>Cross-platform audio/video processing library based on FFmpeg native libraries. Supports audio/video frames extraction (fast access to any frame by timestamp), reading file metadata and encoding media files from bitmap images and audio data.</Description>
     <PackageTags>ffmpeg;video;audio;encoder;encoding;decoder;decoding;h264;mp4;c#;netstandard;netcore;frame-extraction</PackageTags>
     <RepositoryUrl>https://github.com/radek-k/FFMediaToolkit</RepositoryUrl>
@@ -37,7 +38,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FFmpeg.AutoGen" Version="6.0.0.2" />
+    <PackageReference Include="FFmpeg.AutoGen" Version="7.1.1" />
     <PackageReference Include="MinVer" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/FFMediaToolkit/FFmpegLoader.cs
+++ b/FFMediaToolkit/FFmpegLoader.cs
@@ -118,7 +118,7 @@
                 catch (DirectoryNotFoundException)
                 {
                     throw new DirectoryNotFoundException("Cannot found the default FFmpeg directory.\n" +
-                        "On Windows you have to set \"FFmpegLoader.FFmpegPath\" with full path to the directory containing FFmpeg 5.x shared build \".dll\" files\n" +
+                        "On Windows you have to set \"FFmpegLoader.FFmpegPath\" with full path to the directory containing FFmpeg 7.x shared build \".dll\" files\n" +
                         "For more informations please see https://github.com/radek-k/FFMediaToolkit#setup");
                 }
             }
@@ -172,7 +172,7 @@
         /// <param name="exception">The original exception.</param>
         internal static void HandleLibraryLoadError(Exception exception)
         {
-            throw new DllNotFoundException($"Cannot load FFmpeg libraries from {FFmpegPath} directory.\nRequired FFmpeg version: 6.x (shared build)\nMake sure the \"Build\"Prefer 32-bit\" option in the project settings is turned off.\nFor more information please see https://github.com/radek-k/FFMediaToolkit#setup", exception);
+            throw new DllNotFoundException($"Cannot load FFmpeg libraries from {FFmpegPath} directory.\nRequired FFmpeg version: 7.x (shared build)\nMake sure the \"Build\"Prefer 32-bit\" option in the project settings is turned off.\nFor more information please see https://github.com/radek-k/FFMediaToolkit#setup", exception);
         }
     }
 }


### PR DESCRIPTION
This PR adds support for FFmpeg 7.1 by updating the NuGet package for FFmpeg.AutoGen and replacing deprecated API calls with their modern counterparts. Fixes #141.