### PR TITLE
Implement support for HDR10 pixel formats

### DIFF
--- a/FFMediaToolkit/Graphics/ImageData.cs
+++ b/FFMediaToolkit/Graphics/ImageData.cs
@@ -180,6 +180,8 @@
                     return 16;
                 case ImagePixelFormat.Gray8:
                     return 8;
+                case ImagePixelFormat.Rgba64:
+                    return 64;
                 default:
                     return 0;
             }

--- a/FFMediaToolkit/Graphics/ImagePixelFormat.cs
+++ b/FFMediaToolkit/Graphics/ImagePixelFormat.cs
@@ -33,6 +33,11 @@
         Argb32 = AVPixelFormat.AV_PIX_FMT_ARGB,
 
         /// <summary>
+        /// Represents a RGBA(with alpha channel) 64bpp bitmap pixel format.
+        /// </summary>
+        Rgba64 = AVPixelFormat.AV_PIX_FMT_RGBA64LE,
+
+        /// <summary>
         /// Represents a UYVY422 pixel format.
         /// </summary>
         Uyvy422 = AVPixelFormat.AV_PIX_FMT_UYVY422,
@@ -51,6 +56,11 @@
         /// Represents a YUV 12bpp 4:2:0 video pixel format.
         /// </summary>
         Yuv420 = AVPixelFormat.AV_PIX_FMT_YUV420P,
+
+        /// <summary>
+        /// Represents a YUV 15bpp 4:2:0 video pixel format.
+        /// </summary>
+        Yuv42010 = AVPixelFormat.AV_PIX_FMT_YUV420P10LE,
 
         /// <summary>
         /// Represents a Gray 16bpp little-endian video pixel format.


### PR DESCRIPTION
This PR adds indirect support for HDR10 encoding/decoding by extending the FFMediaToolkit API. 
These extensions include updates to `ImagePixelFormat` and `ImageConverter` datatypes.