### PR TITLE
Fix FFmpegLoader to use executable base directory on Windows

### DIFF
--- a/FFMediaToolkit/Interop/NativeMethods.cs
+++ b/FFMediaToolkit/Interop/NativeMethods.cs
@@ -22,7 +22,7 @@
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                return Environment.CurrentDirectory + WindowsDefaultDirectory;
+                return AppDomain.CurrentDomain.BaseDirectory + WindowsDefaultDirectory;
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {


### PR DESCRIPTION
This PR fixes a critical issue within the `FFmpegLoader` class on Windows devices that impacts applications which are used in working directories outside that of the base executable. 