### PR TITLE
Add preliminary support for VVenC based H.266 codec

### DIFF
--- a/FFMediaToolkit/Encoding/EncoderPreset.cs
+++ b/FFMediaToolkit/Encoding/EncoderPreset.cs
@@ -3,7 +3,7 @@
     using System.ComponentModel;
 
     /// <summary>
-    /// The presets for H264 and H265 (HEVC) video encoders.
+    /// The presets for H264, H265 (HEVC), and H266 (VVC) video encoders.
     /// <para>Fast presets = faster encoding, worse compression.</para>
     /// <para>Slow presets = longer encoding, better compression.</para>
     /// </summary>

--- a/FFMediaToolkit/Encoding/Internal/OutputStreamFactory.cs
+++ b/FFMediaToolkit/Encoding/Internal/OutputStreamFactory.cs
@@ -62,7 +62,12 @@
                 dict["crf"] = config.CRF.Value.ToString();
             }
 
-            if (config.Codec.IsMatch(VideoCodec.H264, VideoCodec.H265))
+            if (config.QP.HasValue && config.Codec.IsMatch(VideoCodec.H266))
+            {
+                dict["qp"] = config.QP.Value.ToString();
+            }
+
+            if (config.Codec.IsMatch(VideoCodec.H264, VideoCodec.H265, VideoCodec.H266))
             {
                 dict["preset"] = config.EncoderPreset.GetDescription();
             }

--- a/FFMediaToolkit/Encoding/VideoCodec.cs
+++ b/FFMediaToolkit/Encoding/VideoCodec.cs
@@ -39,6 +39,11 @@
         H265 = AVCodecID.AV_CODEC_ID_HEVC,
 
         /// <summary>
+        /// Versitile Video Coding (VVC) - H.266 codec
+        /// </summary>
+        H266 = AVCodecID.AV_CODEC_ID_VVC,
+
+        /// <summary>
         /// Microsoft Windows Media Video 9 (WMV3)
         /// </summary>
         WMV = AVCodecID.AV_CODEC_ID_WMV3,

--- a/FFMediaToolkit/Encoding/VideoEncoderSettings.cs
+++ b/FFMediaToolkit/Encoding/VideoEncoderSettings.cs
@@ -78,7 +78,12 @@
         public int? CRF { get; set; }
 
         /// <summary>
-        /// Gets or sets the encoder preset. It supports only H.264 and H.265 codecs.
+        /// Gets or sets the Quantization Parameter. It supports only the H.266 codec.
+        /// </summary>
+        public int? QP { get; set; }
+
+        /// <summary>
+        /// Gets or sets the encoder preset. It supports only H.264, H.265, and H.266 codecs.
         /// </summary>
         public EncoderPreset EncoderPreset { get; set; }
 

--- a/FFMediaToolkit/Graphics/ImageData.cs
+++ b/FFMediaToolkit/Graphics/ImageData.cs
@@ -180,6 +180,8 @@
                     return 16;
                 case ImagePixelFormat.Gray8:
                     return 8;
+                case ImagePixelFormat.Rgba64:
+                    return 64;
                 default:
                     return 0;
             }

--- a/FFMediaToolkit/Graphics/ImagePixelFormat.cs
+++ b/FFMediaToolkit/Graphics/ImagePixelFormat.cs
@@ -33,6 +33,11 @@
         Argb32 = AVPixelFormat.AV_PIX_FMT_ARGB,
 
         /// <summary>
+        /// Represents a RGBA(with alpha channel) 64bpp bitmap pixel format.
+        /// </summary>
+        Rgba64 = AVPixelFormat.AV_PIX_FMT_RGBA64LE,
+
+        /// <summary>
         /// Represents a UYVY422 pixel format.
         /// </summary>
         Uyvy422 = AVPixelFormat.AV_PIX_FMT_UYVY422,
@@ -51,6 +56,11 @@
         /// Represents a YUV 12bpp 4:2:0 video pixel format.
         /// </summary>
         Yuv420 = AVPixelFormat.AV_PIX_FMT_YUV420P,
+
+        /// <summary>
+        /// Represents a YUV 15bpp 4:2:0 video pixel format.
+        /// </summary>
+        Yuv42010 = AVPixelFormat.AV_PIX_FMT_YUV420P10LE,
 
         /// <summary>
         /// Represents a Gray 16bpp little-endian video pixel format.


### PR DESCRIPTION
This PR adds preliminary support for Versitile Video Coding (VVC / H.266) to FFMediaToolkit by implementing HDR aware pixel formats and modifying `OutputStreamFactory` and `VideoEncoderOptions` to set VVenC-specfiic parameters. 