### PR TITLE
Specifying decoder codec name

### DIFF
--- a/FFMediaToolkit/.editorconfig
+++ b/FFMediaToolkit/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.cs]
+
+csharp_prefer_braces = true
+csharp_new_line_before_open_brace = all
+csharp_preserve_single_line_blocks = false

--- a/FFMediaToolkit/Decoding/Internal/DecoderFactory.cs
+++ b/FFMediaToolkit/Decoding/Internal/DecoderFactory.cs
@@ -21,11 +21,22 @@
             var format = container.Pointer;
             AVCodec* codec = null;
 
-            var index = ffmpeg.av_find_best_stream(format, stream->codecpar->codec_type, stream->index, -1, &codec, 0);
-            index.IfError(ffmpeg.AVERROR_DECODER_NOT_FOUND, "Cannot find a codec for the specified stream.");
-            if (index < 0)
+            if (!string.IsNullOrEmpty(options.CodecName))
             {
-                return null;
+                codec = ffmpeg.avcodec_find_decoder_by_name(options.CodecName);
+                if (codec == null)
+                {
+                    throw new FFmpegException($"Cannot find a codec with the name '{options.CodecName}'.");
+                }
+            }
+            else
+            {
+                var index = ffmpeg.av_find_best_stream(format, stream->codecpar->codec_type, stream->index, -1, &codec, 0);
+                index.IfError(ffmpeg.AVERROR_DECODER_NOT_FOUND, "Cannot find a codec for the specified stream.");
+                if (index < 0)
+                {
+                    return null;
+                }
             }
 
             var codecContext = ffmpeg.avcodec_alloc_context3(codec);

--- a/FFMediaToolkit/Decoding/Internal/DecoderFactory.cs
+++ b/FFMediaToolkit/Decoding/Internal/DecoderFactory.cs
@@ -21,12 +21,20 @@
             var format = container.Pointer;
             AVCodec* codec = null;
 
-            if (!string.IsNullOrEmpty(options.CodecName))
+            if (stream->codecpar->codec_type == AVMediaType.AVMEDIA_TYPE_VIDEO && !string.IsNullOrEmpty(options.VideoCodecName))
             {
-                codec = ffmpeg.avcodec_find_decoder_by_name(options.CodecName);
+                codec = ffmpeg.avcodec_find_decoder_by_name(options.VideoCodecName);
                 if (codec == null)
                 {
-                    throw new FFmpegException($"Cannot find a codec with the name '{options.CodecName}'.");
+                    throw new FFmpegException($"Cannot find a codec with the name '{options.VideoCodecName}'.");
+                }
+            }
+            else if (stream->codecpar->codec_type == AVMediaType.AVMEDIA_TYPE_AUDIO && !string.IsNullOrEmpty(options.AudioCodecName))
+            {
+                codec = ffmpeg.avcodec_find_decoder_by_name(options.AudioCodecName);
+                if (codec == null)
+                {
+                    throw new FFmpegException($"Cannot find a codec with the name '{options.AudioCodecName}'.");
                 }
             }
             else

--- a/FFMediaToolkit/Decoding/MediaOptions.cs
+++ b/FFMediaToolkit/Decoding/MediaOptions.cs
@@ -43,6 +43,11 @@
         }
 
         /// <summary>
+        /// Gets or sets manually chosen decoder. Default is automatic selection based on stream.
+        /// </summary>
+        public string CodecName { get; set; } = null;
+
+        /// <summary>
         /// Gets or sets the limit of memory used by the packet buffer. Default limit is 40 MB per stream.
         /// </summary>
         public int PacketBufferSizeLimit { get; set; } = 40;

--- a/FFMediaToolkit/Decoding/MediaOptions.cs
+++ b/FFMediaToolkit/Decoding/MediaOptions.cs
@@ -43,9 +43,14 @@
         }
 
         /// <summary>
-        /// Gets or sets manually chosen decoder. Default is automatic selection based on stream.
+        /// Gets or sets manually chosen audio decoder. Default is automatic selection based on stream.
         /// </summary>
-        public string CodecName { get; set; } = null;
+        public string AudioCodecName { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets manually chosen video decoder. Default is automatic selection based on stream.
+        /// </summary>
+        public string VideoCodecName { get; set; } = null;
 
         /// <summary>
         /// Gets or sets the limit of memory used by the packet buffer. Default limit is 40 MB per stream.


### PR DESCRIPTION
Adds options to specify audio and video decoder codec names, which overrides default automatic codec selection when set.

Roughly an equivalent of `ffmpeg -c:v <video-codec> -c:a <audio-codec> -i in.mp4 out.mp4`

There're multiple decoders for some formats, so choosing becomes necessary in some cases.

I need this specifically for switching `vp8` -> `libvpx` and `vp9` -> `libvpx-vp9`. The default codec doesn't support alpha channel. Some FFmpeg wrappers choose to always override codec for VPx, which can be implemented too, if necessary.

The current limitation is that the options override codec selection for all audio and video streams, so it won't work in case of multiple streams of the same type using different codecs. Some sort of `Func<StreamInfo, string> CodecSelector` can be implemented if necessary.