### PR TITLE
Sample aspect ratio support

### DIFF
--- a/FFMediaToolkit/Decoding/MediaOptions.cs
+++ b/FFMediaToolkit/Decoding/MediaOptions.cs
@@ -61,6 +61,12 @@
         /// Gets or sets the target video size for decoded video frames conversion. <see langword="null"/>, if no rescale.
         /// </summary>
         public Size? TargetVideoSize { get; set; }
+        
+        /// <summary>
+        /// Gets or sets a value indicating whether frames should be scaled based on SAR value(if set).
+        /// When this option is enabled <see cref="TargetVideoSize"/> value is ignored.
+        /// </summary>
+        public bool RespectSampleAspectRatio { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether video frames will be flipped vertically.

--- a/FFMediaToolkit/Decoding/VideoStream.cs
+++ b/FFMediaToolkit/Decoding/VideoStream.cs
@@ -26,6 +26,14 @@
             : base(stream, options, options.VideoSeekThreshold)
         {
             outputFrameSize = options.TargetVideoSize ?? Info.FrameSize;
+            
+            if (options.RespectSampleAspectRatio &&
+                Info.SampleAspectRatio.num > 1)
+            {
+                double width = (double)Info.SampleAspectRatio.num / Info.SampleAspectRatio.den * Info.FrameSize.Width;
+                outputFrameSize = new Size((int)width, Info.FrameSize.Height);
+            }
+            
             converter = new ImageConverter(outputFrameSize, (AVPixelFormat)options.VideoPixelFormat, options.FlipVertically);
 
             FrameStride = ImageData.EstimateStride(outputFrameSize.Width, Options.VideoPixelFormat);

--- a/FFMediaToolkit/Decoding/VideoStreamInfo.cs
+++ b/FFMediaToolkit/Decoding/VideoStreamInfo.cs
@@ -27,6 +27,7 @@
             FrameSize = new Size(codec->width, codec->height);
             PixelFormat = ((AVPixelFormat)codec->format).FormatEnum(11);
             AVPixelFormat = (AVPixelFormat)codec->format;
+            SampleAspectRatio = stream->sample_aspect_ratio;
 
             var packetSideData = ffmpeg.av_packet_side_data_get(codec->coded_side_data, codec->nb_coded_side_data, AVPacketSideDataType.AV_PKT_DATA_DISPLAYMATRIX);
             if (packetSideData != null)
@@ -54,6 +55,12 @@
         /// Gets a lowercase string representing the video pixel format.
         /// </summary>
         public string PixelFormat { get; }
+        
+        /// <summary>
+        /// Gets sample aspect ratio.
+        /// 0 if unknown.
+        /// </summary>
+        public AVRational SampleAspectRatio { get; }
 
         /// <summary>
         /// Gets the video pixel format.


### PR DESCRIPTION
I don't know what the logic behind not merging this is, but there're a few changes in @hey-red's fork:

* `MediaOptions.RespectSampleAspectRatio` property to resize frame when decoding
* Informational `VideoStreamInfo.SampleAspectRatio` property

They're used in https://github.com/hey-red/ImageSharp.AVCodecFormats and seem useful in general.

P.S. Tried creating a pull request from @hey-red's commits to master; got an error saying I need to be a contributor for this. Tried creating an issue in the fork; issues are disabled.

P.P.S. Created a pull request hey-red/FFMediaToolkit#1 by mistake. I guess that's one way to create an issue. 😆