### PR TITLE
Fix: update to use FFmpeg 8.0

### DIFF
--- a/FFMediaToolkit/Common/Internal/ImageConverter.cs
+++ b/FFMediaToolkit/Common/Internal/ImageConverter.cs
@@ -96,8 +96,8 @@
             {
                 ffmpeg.sws_freeContext(Pointer);
 
-                var scaleMode = sourceSize == destinationSize ? ffmpeg.SWS_POINT : ffmpeg.SWS_BICUBIC;
-                var swsContext = ffmpeg.sws_getContext(sourceSize.Width, sourceSize.Height, sourceFormat, destinationSize.Width, destinationSize.Height, destinationFormat, scaleMode, null, null, null);
+                var scaleMode = sourceSize == destinationSize ? SwsFlags.SWS_POINT : SwsFlags.SWS_BICUBIC;
+                var swsContext = ffmpeg.sws_getContext(sourceSize.Width, sourceSize.Height, sourceFormat, destinationSize.Width, destinationSize.Height, destinationFormat, (int)scaleMode, null, null, null);
 
                 if (swsContext == null)
                 {

--- a/FFMediaToolkit/FFMediaToolkit.csproj
+++ b/FFMediaToolkit/FFMediaToolkit.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FFmpeg.AutoGen" Version="7.1.1" />
+    <PackageReference Include="FFmpeg.AutoGen" Version="8.0.0" />
     <PackageReference Include="MinVer" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/FFMediaToolkit/FFmpegLoader.cs
+++ b/FFMediaToolkit/FFmpegLoader.cs
@@ -118,7 +118,7 @@
                 catch (DirectoryNotFoundException)
                 {
                     throw new DirectoryNotFoundException("Cannot found the default FFmpeg directory.\n" +
-                        "On Windows you have to set \"FFmpegLoader.FFmpegPath\" with full path to the directory containing FFmpeg 7.x shared build \".dll\" files\n" +
+                        "On Windows you have to set \"FFmpegLoader.FFmpegPath\" with full path to the directory containing FFmpeg 8.0.x shared build \".dll\" files\n" +
                         "For more informations please see https://github.com/radek-k/FFMediaToolkit#setup");
                 }
             }
@@ -172,7 +172,7 @@
         /// <param name="exception">The original exception.</param>
         internal static void HandleLibraryLoadError(Exception exception)
         {
-            throw new DllNotFoundException($"Cannot load FFmpeg libraries from {FFmpegPath} directory.\nRequired FFmpeg version: 7.x (shared build)\nMake sure the \"Build\"Prefer 32-bit\" option in the project settings is turned off.\nFor more information please see https://github.com/radek-k/FFMediaToolkit#setup", exception);
+            throw new DllNotFoundException($"Cannot load FFmpeg libraries from {FFmpegPath} directory.\nRequired FFmpeg version: 8.0.x (shared build)\nMake sure the \"Build\"Prefer 32-bit\" option in the project settings is turned off.\nFor more information please see https://github.com/radek-k/FFMediaToolkit#setup", exception);
         }
     }
 }


### PR DESCRIPTION
This PR makes minor changes to the FFMediaToolkit library to support the latest FFmpeg bindings for version 8.0.